### PR TITLE
feat(game): board + piece + SRS red (#5)

### DIFF
--- a/src/game/board.rs
+++ b/src/game/board.rs
@@ -5,6 +5,7 @@ use crate::game::piece::PieceKind;
 /// Rows 0..20 are the hidden buffer (spawn area).
 /// Rows 20..40 are the visible playfield.
 /// Origin (0, 0) is top-left; x increases rightward, y increases downward.
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Board {
     cells: [[Option<PieceKind>; 10]; 40],
 }
@@ -35,28 +36,40 @@ impl Board {
 
     /// Clear all fully-occupied rows, shift everything above down,
     /// and return the number of rows cleared.
+    ///
+    /// When no rows are full, the board is left completely untouched.
     pub fn clear_full_rows(&mut self) -> u8 {
-        let mut cleared: u8 = 0;
-        let mut write_row = 39_usize;
-
-        // Walk rows from bottom to top; copy non-full rows into write_row.
-        let mut read_row = 39_i64;
-        while read_row >= 0 {
-            let r = read_row as usize;
-            if self.cells[r].iter().all(|c| c.is_some()) {
-                // Full row — skip it (don't copy), count as cleared.
-                cleared += 1;
-            } else {
-                // Non-full row — copy to write_row.
-                self.cells[write_row] = self.cells[r];
-                write_row = write_row.saturating_sub(1);
-            }
-            read_row -= 1;
+        // First pass: count full rows. If zero, return without mutating
+        // any cells — this avoids the off-by-one that would erase row 0.
+        let cleared: u8 = self
+            .cells
+            .iter()
+            .filter(|row| row.iter().all(|c| c.is_some()))
+            .count() as u8;
+        if cleared == 0 {
+            return 0;
         }
 
-        // Fill the top rows that were vacated with empty rows.
+        // Second pass: compact non-full rows downward, bottom-up.
+        // `write_row` is the destination; iterate from row 39 down to 0.
+        let mut write_row: i64 = 39;
+        for read_row in (0..40_i64).rev() {
+            let r = read_row as usize;
+            if self.cells[r].iter().all(|c| c.is_some()) {
+                // Full row — skip (do not copy).
+                continue;
+            }
+            self.cells[write_row as usize] = self.cells[r];
+            write_row -= 1;
+        }
+
+        // Any rows above the final write_row were vacated — fill them
+        // with empty cells. `write_row` now points one row above the
+        // topmost compacted row (may be -1 if every row was cleared,
+        // which is impossible here since cleared <= 40 and we only
+        // reach this branch when some full rows existed).
         for r in 0..=write_row {
-            self.cells[r] = [None; 10];
+            self.cells[r as usize] = [None; 10];
         }
 
         cleared

--- a/src/game/board.rs
+++ b/src/game/board.rs
@@ -1,0 +1,64 @@
+use crate::game::piece::PieceKind;
+
+/// 10-column × 40-row playfield.
+///
+/// Rows 0..20 are the hidden buffer (spawn area).
+/// Rows 20..40 are the visible playfield.
+/// Origin (0, 0) is top-left; x increases rightward, y increases downward.
+pub struct Board {
+    cells: [[Option<PieceKind>; 10]; 40],
+}
+
+impl Board {
+    /// Return an empty board with no occupied cells.
+    pub fn empty() -> Self {
+        Self {
+            cells: [[None; 10]; 40],
+        }
+    }
+
+    /// Return true if the cell at (col, row) is occupied or out-of-bounds.
+    ///
+    /// Out-of-bounds coordinates always return true so that collision
+    /// checks treat walls and floor as solid.
+    pub fn is_occupied(&self, col: i32, row: i32) -> bool {
+        if !(0..10).contains(&col) || !(0..40).contains(&row) {
+            return true;
+        }
+        self.cells[row as usize][col as usize].is_some()
+    }
+
+    /// Place a piece kind at (col, row). Panics if out of bounds.
+    pub fn set(&mut self, col: usize, row: usize, piece: PieceKind) {
+        self.cells[row][col] = Some(piece);
+    }
+
+    /// Clear all fully-occupied rows, shift everything above down,
+    /// and return the number of rows cleared.
+    pub fn clear_full_rows(&mut self) -> u8 {
+        let mut cleared: u8 = 0;
+        let mut write_row = 39_usize;
+
+        // Walk rows from bottom to top; copy non-full rows into write_row.
+        let mut read_row = 39_i64;
+        while read_row >= 0 {
+            let r = read_row as usize;
+            if self.cells[r].iter().all(|c| c.is_some()) {
+                // Full row — skip it (don't copy), count as cleared.
+                cleared += 1;
+            } else {
+                // Non-full row — copy to write_row.
+                self.cells[write_row] = self.cells[r];
+                write_row = write_row.saturating_sub(1);
+            }
+            read_row -= 1;
+        }
+
+        // Fill the top rows that were vacated with empty rows.
+        for r in 0..=write_row {
+            self.cells[r] = [None; 10];
+        }
+
+        cleared
+    }
+}

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -1,0 +1,3 @@
+pub mod board;
+pub mod piece;
+pub mod srs;

--- a/src/game/piece.rs
+++ b/src/game/piece.rs
@@ -1,0 +1,113 @@
+/// The seven piece kinds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PieceKind {
+    I,
+    O,
+    T,
+    S,
+    Z,
+    J,
+    L,
+}
+
+/// The four rotation states.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Rotation {
+    Zero,
+    R,
+    Two,
+    L,
+}
+
+/// A piece on the board: kind, rotation state, and grid origin.
+///
+/// `origin` is the top-left corner of the piece's bounding box in
+/// board coordinates (col, row).  Cell offsets in the shape tables are
+/// relative to this origin.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Piece {
+    pub kind: PieceKind,
+    pub rotation: Rotation,
+    pub origin: (i32, i32),
+}
+
+impl Piece {
+    /// Return absolute board coordinates of this piece's occupied cells.
+    pub fn cells(&self) -> Vec<(i32, i32)> {
+        let offsets = shape_offsets(self.kind, self.rotation);
+        offsets
+            .iter()
+            .map(|&(dc, dr)| (self.origin.0 + dc, self.origin.1 + dr))
+            .collect()
+    }
+}
+
+/// Cell offsets (col_delta, row_delta) relative to the piece origin.
+///
+/// Only `Rotation::Zero` is defined for Sprint 1; other rotations are
+/// Sprint 2 (srs.rs).
+fn shape_offsets(kind: PieceKind, rotation: Rotation) -> &'static [(i32, i32)] {
+    // Sprint 1: only Zero rotation shapes are defined.
+    // Sprint 2 will fill in R, Two, L via srs.rs.
+    match rotation {
+        Rotation::Zero => shape_offsets_zero(kind),
+        // Placeholder: return same shape as Zero until Sprint 2.
+        _ => shape_offsets_zero(kind),
+    }
+}
+
+/// Zero-rotation cell offsets (col, row) relative to bounding-box top-left.
+///
+/// Bounding box convention:
+///   I, J, L, S, T, Z — 4-wide (cols 0..4), 1–2 rows.
+///   O                 — 2-wide (cols 0..2), 2 rows.
+fn shape_offsets_zero(kind: PieceKind) -> &'static [(i32, i32)] {
+    match kind {
+        // I: row 1 of the 4×2 bbox (standard Guideline Zero state)
+        //    ....
+        //    XXXX
+        PieceKind::I => &[(0, 1), (1, 1), (2, 1), (3, 1)],
+        // O: 2×2
+        //    XX
+        //    XX
+        PieceKind::O => &[(0, 0), (1, 0), (0, 1), (1, 1)],
+        // T:
+        //    .X.
+        //    XXX
+        PieceKind::T => &[(1, 0), (0, 1), (1, 1), (2, 1)],
+        // S:
+        //    .XX
+        //    XX.
+        PieceKind::S => &[(1, 0), (2, 0), (0, 1), (1, 1)],
+        // Z:
+        //    XX.
+        //    .XX
+        PieceKind::Z => &[(0, 0), (1, 0), (1, 1), (2, 1)],
+        // J:
+        //    X..
+        //    XXX
+        PieceKind::J => &[(0, 0), (0, 1), (1, 1), (2, 1)],
+        // L:
+        //    ..X
+        //    XXX
+        PieceKind::L => &[(2, 0), (0, 1), (1, 1), (2, 1)],
+    }
+}
+
+/// Spawn a piece at the Guideline-inspired spawn position.
+///
+/// Per SPEC §4 (round-2 decision):
+/// - O: 2-wide bbox top-left at (col=4, row=18) → cells at cols 4..=5.
+/// - I: 4-wide bbox top-left at (col=3, row=18) → bbox cols 3..7.
+/// - J, L, S, T, Z: 4-wide bbox top-left at (col=3, row=18) → bbox cols 3..7.
+pub fn spawn(kind: PieceKind) -> Piece {
+    let origin = match kind {
+        PieceKind::O => (4, 18),
+        _ => (3, 18),
+    };
+    Piece {
+        kind,
+        rotation: Rotation::Zero,
+        origin,
+    }
+}

--- a/src/game/srs.rs
+++ b/src/game/srs.rs
@@ -1,0 +1,22 @@
+use crate::game::piece::Piece;
+
+/// Rotation direction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RotationDir {
+    Cw,
+    Ccw,
+}
+
+/// Errors returned by `rotate`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SrsError {
+    /// All SRS kick offsets were blocked; rotation rejected.
+    Blocked,
+}
+
+/// Rotate `piece` in direction `dir` using SRS kick tables.
+///
+/// Full implementation deferred to Sprint 2.
+pub fn rotate(_piece: &Piece, _dir: RotationDir) -> Result<Piece, SrsError> {
+    unimplemented!("srs::rotate — Sprint 2 (issue TBD)")
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod game;

--- a/tests/board.rs
+++ b/tests/board.rs
@@ -61,6 +61,31 @@ fn clear_full_rows_counts_and_shifts_down() {
 }
 
 #[test]
+fn clear_full_rows_on_empty_board_does_not_mutate() {
+    let mut b = Board::empty();
+    b.set(3, 5, PieceKind::I);
+    b.set(3, 10, PieceKind::T);
+    let snapshot_before = b.clone();
+    let cleared = b.clear_full_rows();
+    assert_eq!(cleared, 0);
+    assert_eq!(b, snapshot_before);
+}
+
+#[test]
+fn clear_full_rows_leaves_partial_row_intact() {
+    let mut b = Board::empty();
+    for c in 0..9 {
+        b.set(c, 25, PieceKind::I);
+    }
+    let cleared = b.clear_full_rows();
+    assert_eq!(cleared, 0);
+    for c in 0..9 {
+        assert!(b.is_occupied(c, 25));
+    }
+    assert!(!b.is_occupied(9, 25));
+}
+
+#[test]
 fn block_out_detected() {
     // Spawn cells for O are cols 4 and 5, rows 18..20.
     // Fill one of those cells to simulate block-out condition.

--- a/tests/board.rs
+++ b/tests/board.rs
@@ -1,0 +1,78 @@
+use blocktxt::game::board::Board;
+use blocktxt::game::piece::PieceKind;
+
+#[test]
+fn empty_board_has_no_occupancy_on_visible_rows() {
+    let board = Board::empty();
+    for row in 20..40 {
+        for col in 0..10 {
+            assert!(
+                !board.is_occupied(col, row),
+                "expected empty at col={col} row={row}"
+            );
+        }
+    }
+}
+
+#[test]
+fn set_and_is_occupied_round_trip() {
+    let mut board = Board::empty();
+    board.set(3, 25, PieceKind::T);
+    assert!(board.is_occupied(3, 25));
+    assert!(!board.is_occupied(4, 25));
+    assert!(!board.is_occupied(3, 26));
+}
+
+#[test]
+fn out_of_bounds_reads_as_occupied() {
+    let board = Board::empty();
+    // negative col
+    assert!(board.is_occupied(-1, 20));
+    // negative row
+    assert!(board.is_occupied(0, -1));
+    // col >= 10
+    assert!(board.is_occupied(10, 20));
+    // row >= 40
+    assert!(board.is_occupied(0, 40));
+}
+
+#[test]
+fn clear_full_rows_counts_and_shifts_down() {
+    let mut board = Board::empty();
+    // Fill row 39 (bottom visible row) completely.
+    for col in 0..10 {
+        board.set(col, 39, PieceKind::I);
+    }
+    // Partially fill row 38.
+    board.set(0, 38, PieceKind::O);
+
+    let cleared = board.clear_full_rows();
+    assert_eq!(cleared, 1, "expected 1 cleared row");
+
+    // The partial row should have shifted down by one.
+    assert!(
+        board.is_occupied(0, 39),
+        "partial row should shift to row 39"
+    );
+    assert!(!board.is_occupied(0, 38), "row 38 should now be empty");
+
+    // Row 39 col 1 should be empty (was not filled in partial row).
+    assert!(!board.is_occupied(1, 39));
+}
+
+#[test]
+fn block_out_detected() {
+    // Spawn cells for O are cols 4 and 5, rows 18..20.
+    // Fill one of those cells to simulate block-out condition.
+    let mut board = Board::empty();
+    board.set(4, 18, PieceKind::I);
+
+    // A newly spawning O piece would have cells at (4,18),(5,18),(4,19),(5,19).
+    // Collision against board means block-out.
+    let spawn_cells: [(i32, i32); 4] = [(4, 18), (5, 18), (4, 19), (5, 19)];
+    let blocked = spawn_cells.iter().any(|&(c, r)| board.is_occupied(c, r));
+    assert!(
+        blocked,
+        "block-out should be detected when spawn cells are occupied"
+    );
+}

--- a/tests/piece.rs
+++ b/tests/piece.rs
@@ -1,0 +1,57 @@
+use blocktxt::game::piece::{spawn, PieceKind, Rotation};
+
+#[test]
+fn o_spawns_at_cols_4_and_5() {
+    let piece = spawn(PieceKind::O);
+    assert!(matches!(piece.rotation, Rotation::Zero));
+
+    // O piece cells: (4,18),(5,18),(4,19),(5,19)
+    let cells = piece.cells();
+    let cols: Vec<i32> = cells.iter().map(|&(c, _)| c).collect();
+    assert!(cols.contains(&4), "O should occupy col 4; cells={cells:?}");
+    assert!(cols.contains(&5), "O should occupy col 5; cells={cells:?}");
+    // Must not occupy cols outside 4..=5
+    for &(c, _) in &cells {
+        assert!((4..=5).contains(&c), "O cell col {c} out of range 4..=5");
+    }
+}
+
+#[test]
+fn jlstz_spawn_bounding_box_is_cols_3_to_7() {
+    for kind in [
+        PieceKind::J,
+        PieceKind::L,
+        PieceKind::S,
+        PieceKind::T,
+        PieceKind::Z,
+    ] {
+        let piece = spawn(kind);
+        let cells = piece.cells();
+        let min_col = cells.iter().map(|&(c, _)| c).min().unwrap();
+        let max_col = cells.iter().map(|&(c, _)| c).max().unwrap();
+        assert!(
+            min_col >= 3,
+            "{kind:?} min col {min_col} should be >= 3; cells={cells:?}"
+        );
+        assert!(
+            max_col <= 6,
+            "{kind:?} max col {max_col} should be <= 6; cells={cells:?}"
+        );
+    }
+}
+
+#[test]
+fn i_spawn_bounding_box_is_cols_3_to_7() {
+    let piece = spawn(PieceKind::I);
+    let cells = piece.cells();
+    let min_col = cells.iter().map(|&(c, _)| c).min().unwrap();
+    let max_col = cells.iter().map(|&(c, _)| c).max().unwrap();
+    assert!(
+        min_col >= 3,
+        "I min col {min_col} should be >= 3; cells={cells:?}"
+    );
+    assert!(
+        max_col <= 6,
+        "I max col {max_col} should be <= 6; cells={cells:?}"
+    );
+}

--- a/tests/srs_rotation.rs
+++ b/tests/srs_rotation.rs
@@ -1,25 +1,19 @@
-use blocktxt::game::piece::{spawn, PieceKind};
+use blocktxt::game::piece::{spawn, PieceKind, Rotation};
 use blocktxt::game::srs::{rotate, RotationDir};
 
 /// Red test — Sprint 2 will implement srs::rotate.
 ///
-/// Asserts that rotating the I piece clockwise from state Zero via
-/// `srs::rotate` produces a piece whose origin has moved by the
-/// expected SRS kick offset. Sprint 1's srs::rotate is
-/// `unimplemented!()`, so this test panics; #[ignore] keeps CI green.
+/// For the I piece, the SRS Zero→R wall-kick table starts with the
+/// `(0, 0)` offset on an open board — so rotation succeeds without
+/// displacing the origin. Sprint 1's `srs::rotate` is
+/// `unimplemented!()`, so this test panics; `#[ignore]` keeps CI green
+/// until Sprint 2.
 #[test]
 #[ignore = "red: Sprint 2 will implement srs::rotate"]
 fn srs_i_rotation_clockwise_applies_kick_offset() {
     let piece = spawn(PieceKind::I);
-    // Expected: CW rotation from Zero→R succeeds (no board, no collision).
-    let rotated = rotate(&piece, RotationDir::Cw)
-        .expect("CW rotation of I from Zero should succeed with no board obstacles");
-    // The rotated piece origin must differ from the spawn origin by the
-    // SRS Zero→R kick offset for I: (0, 0) is the first test point
-    // (no displacement needed on an open board), but the rotation
-    // state must change.
-    assert_ne!(
-        rotated.origin, piece.origin,
-        "expected origin to shift under SRS kick for I CW"
-    );
+    let rotated = rotate(&piece, RotationDir::Cw).expect("rotation ok");
+    assert_eq!(rotated.rotation, Rotation::R);
+    // I Zero→R: (0, 0) kick on an open board — origin does not move.
+    assert_eq!(rotated.origin, piece.origin);
 }

--- a/tests/srs_rotation.rs
+++ b/tests/srs_rotation.rs
@@ -1,0 +1,25 @@
+use blocktxt::game::piece::{spawn, PieceKind};
+use blocktxt::game::srs::{rotate, RotationDir};
+
+/// Red test — Sprint 2 will implement srs::rotate.
+///
+/// Asserts that rotating the I piece clockwise from state Zero via
+/// `srs::rotate` produces a piece whose origin has moved by the
+/// expected SRS kick offset. Sprint 1's srs::rotate is
+/// `unimplemented!()`, so this test panics; #[ignore] keeps CI green.
+#[test]
+#[ignore = "red: Sprint 2 will implement srs::rotate"]
+fn srs_i_rotation_clockwise_applies_kick_offset() {
+    let piece = spawn(PieceKind::I);
+    // Expected: CW rotation from Zero→R succeeds (no board, no collision).
+    let rotated = rotate(&piece, RotationDir::Cw)
+        .expect("CW rotation of I from Zero should succeed with no board obstacles");
+    // The rotated piece origin must differ from the spawn origin by the
+    // SRS Zero→R kick offset for I: (0, 0) is the first test point
+    // (no displacement needed on an open board), but the rotation
+    // state must change.
+    assert_ne!(
+        rotated.origin, piece.origin,
+        "expected origin to shift under SRS kick for I CW"
+    );
+}


### PR DESCRIPTION
## Summary

- Add `src/lib.rs` (Option A) so integration tests import via `use blocktxt::game::...` without touching `src/main.rs`; Cargo infers both lib and bin crates automatically.
- Implement `src/game/board.rs`: 10×40 `Board` with `empty()`, `is_occupied()` (OOB reads as occupied), `set()`, and `clear_full_rows() -> u8`.
- Implement `src/game/piece.rs`: `PieceKind`, `Rotation`, `Piece` with `cells()`, `const` shape tables for `Rotation::Zero`, and `spawn()` per SPEC §4 round-2 coords (O at cols 4+5; I/JLSTZ 4-wide bbox at cols 3..7).
- Add `src/game/srs.rs` stub: `RotationDir`, `SrsError`, and `rotate()` returning `unimplemented!("Sprint 2")`.

## Test plan

- [ ] `tests/board.rs` — 5 tests all pass: `empty_board_has_no_occupancy_on_visible_rows`, `set_and_is_occupied_round_trip`, `out_of_bounds_reads_as_occupied`, `clear_full_rows_counts_and_shifts_down`, `block_out_detected`.
- [ ] `tests/piece.rs` — 3 tests all pass: `o_spawns_at_cols_4_and_5`, `jlstz_spawn_bounding_box_is_cols_3_to_7`, `i_spawn_bounding_box_is_cols_3_to_7`.
- [ ] `tests/srs_rotation.rs` — 1 test `srs_i_rotation_clockwise_applies_kick_offset` is `#[ignore = "red: Sprint 2 will implement srs::rotate"]`; CI stays green.
- [ ] `cargo fmt --all -- --check` passes.
- [ ] `cargo clippy --all-targets -- -D warnings` passes.
- [ ] `bash scripts/check-naming.sh` passes.

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)