### PR TITLE
feat(signals): TerminalGuard + flag signals (#3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,7 @@ dependencies = [
  "crossterm 0.29.0",
  "directories",
  "insta",
+ "nix",
  "proptest",
  "rand",
  "rand_chacha",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/NikolayS/tetris-tui-1"
 anyhow = "1.0.102"
 clap = { version = "4.5.61", features = ["derive"] }
 crossterm = "0.29.0"
+nix = { version = "0.31", features = ["signal"] }
 directories = "6.0.0"
 rand = "0.9.4"
 rand_chacha = "0.9.0"
@@ -24,5 +25,6 @@ thiserror = "2.0.18"
 [dev-dependencies]
 assert_cmd = "2.1.2"
 insta = "1.47.2"
+nix = { version = "0.31", features = ["signal", "term"] }
 proptest = "1.8.0"
 rexpect = "0.6.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,105 @@
+mod signals;
+mod terminal;
+
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use crossterm::event;
+use terminal::{install_panic_hook, TerminalGuard};
+
 fn main() -> anyhow::Result<()> {
+    // Install the panic hook BEFORE guard setup so the terminal is restored
+    // even if setup panics.
+    install_panic_hook();
+
+    // Hidden flag used by PTY tests: panic immediately after guard entry to
+    // verify that the panic hook restores the terminal.  Issue #4 will
+    // replace the args() check with a proper clap subcommand.
+    let crash_for_test = std::env::args().any(|a| a == "--crash-for-test");
+
+    // Install signal flags BEFORE guard enter so Ctrl-C works if guard
+    // setup fails partway through.
+    #[cfg(unix)]
+    let flags = signals::unix::install()?;
+
+    let mut guard = TerminalGuard::enter()?;
+
+    if crash_for_test {
+        panic!("--crash-for-test: intentional panic after guard entry");
+    }
+
+    run_loop(&mut guard, &flags)?;
+
+    Ok(())
+}
+
+/// Main event loop skeleton (Sprint 1 stub).
+///
+/// Observes signal flags each tick (ordered per SPEC §3 data-flow):
+///
+///   shutdown → exit clean
+///   tstp_pending → restore terminal, raise SIGSTOP; on SIGCONT re-enter
+///   cont_pending → re-enter raw/alt mode, force redraw
+///   winch_pending → (Sprint 2) query size, redraw
+///
+/// The loop body is a stub for Sprint 2: polls crossterm events with an
+/// 8 ms timeout per SPEC §4 frame cadence.
+#[cfg(unix)]
+fn run_loop(guard: &mut TerminalGuard, flags: &signals::unix::Flags) -> anyhow::Result<()> {
+    use nix::sys::signal::{self, Signal};
+
+    loop {
+        // --- 1. Check signal flags (ordered) ---
+
+        if flags.shutdown.swap(false, Ordering::Relaxed) {
+            break;
+        }
+
+        if flags.tstp_pending.swap(false, Ordering::Relaxed) {
+            // Restore terminal before stopping so the shell gets a sane tty.
+            guard.restore();
+            // Raise SIGSTOP to actually pause the process.  The kernel will
+            // deliver SIGCONT later when the user does `fg`.
+            let _ = signal::raise(Signal::SIGSTOP);
+            // When we wake from SIGSTOP (SIGCONT delivered), re-enter TUI.
+            guard.re_enter()?;
+            flags.cont_pending.store(false, Ordering::Relaxed);
+            flags.winch_pending.store(true, Ordering::Relaxed);
+            continue;
+        }
+
+        if flags.cont_pending.swap(false, Ordering::Relaxed) {
+            guard.re_enter()?;
+            flags.winch_pending.store(true, Ordering::Relaxed);
+        }
+
+        if flags.winch_pending.swap(false, Ordering::Relaxed) {
+            // Sprint 2 will query terminal size and redraw here.
+        }
+
+        // --- 2. Poll for crossterm events (8 ms timeout) ---
+        if event::poll(Duration::from_millis(8))? {
+            let ev = event::read()?;
+            // Sprint 2 will translate events → Inputs here.
+            // For now exit cleanly on 'q'.
+            if let event::Event::Key(key) = ev {
+                use crossterm::event::{KeyCode, KeyEvent};
+                if let KeyEvent {
+                    code: KeyCode::Char('q'),
+                    ..
+                } = key
+                {
+                    break;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// Non-unix stub so the crate still compiles on Windows (WSL takes the unix path).
+#[cfg(not(unix))]
+fn run_loop(_guard: &mut TerminalGuard, _flags: &()) -> anyhow::Result<()> {
     Ok(())
 }

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -1,0 +1,52 @@
+/// Async-signal-safe signal flags for the main loop.
+///
+/// Each field is an `Arc<AtomicBool>` that a signal handler sets to `true`
+/// using `Ordering::SeqCst`.  All terminal I/O that must happen in response
+/// to a signal is done by the main loop observing the flag on its next tick;
+/// handlers never touch the terminal directly.
+///
+/// This design follows the SPEC §3 "app.rs ↔ signals.rs" seam: handlers
+/// only do `AtomicBool::store(true, SeqCst)` — no other syscalls, no
+/// allocations, no locks.
+#[cfg(unix)]
+pub mod unix {
+    use std::io;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::Arc;
+
+    use signal_hook::consts::signal::{SIGCONT, SIGINT, SIGTERM, SIGTSTP, SIGWINCH};
+
+    /// All signal flags observed by the main loop each tick.
+    #[derive(Clone)]
+    pub struct Flags {
+        /// SIGINT or SIGTERM: clean shutdown requested.
+        pub shutdown: Arc<AtomicBool>,
+        /// SIGTSTP (Ctrl-Z): restore terminal then raise SIGSTOP.
+        pub tstp_pending: Arc<AtomicBool>,
+        /// SIGCONT: re-enter raw/alt mode + force redraw.
+        pub cont_pending: Arc<AtomicBool>,
+        /// SIGWINCH: terminal resized, query new size + redraw.
+        pub winch_pending: Arc<AtomicBool>,
+    }
+
+    /// Register all 5 signal handlers and return the flag set.
+    ///
+    /// Must be called before `TerminalGuard::enter()` so that Ctrl-C is
+    /// handled even if guard setup fails partway through.
+    pub fn install() -> Result<Flags, io::Error> {
+        let flags = Flags {
+            shutdown: Arc::new(AtomicBool::new(false)),
+            tstp_pending: Arc::new(AtomicBool::new(false)),
+            cont_pending: Arc::new(AtomicBool::new(false)),
+            winch_pending: Arc::new(AtomicBool::new(false)),
+        };
+
+        signal_hook::flag::register(SIGINT, Arc::clone(&flags.shutdown))?;
+        signal_hook::flag::register(SIGTERM, Arc::clone(&flags.shutdown))?;
+        signal_hook::flag::register(SIGTSTP, Arc::clone(&flags.tstp_pending))?;
+        signal_hook::flag::register(SIGCONT, Arc::clone(&flags.cont_pending))?;
+        signal_hook::flag::register(SIGWINCH, Arc::clone(&flags.winch_pending))?;
+
+        Ok(flags)
+    }
+}

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,0 +1,190 @@
+/// RAII terminal lifecycle guard.
+///
+/// `TerminalGuard::enter()` enables raw mode, enters the alternate screen,
+/// and hides the cursor — in that order.  On any partial failure the steps
+/// already taken are reversed before the error is returned.
+///
+/// `Drop` unconditionally restores the terminal (idempotent — calling it
+/// multiple times is safe).
+///
+/// A panic hook is installed *before* `enter()` is called (from `main`).
+/// The hook calls the same byte-level restore routine via a `static`
+/// `OnceLock`; it does not touch the guard's state, so the guard's own
+/// `Drop` running afterwards is a harmless no-op.
+use std::io::{self, Write as _};
+use std::sync::OnceLock;
+
+use crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+};
+use crossterm::{cursor, execute, style};
+use thiserror::Error;
+
+/// Errors that can occur during terminal setup.
+#[derive(Debug, Error)]
+pub enum TerminalError {
+    #[error("failed to enable raw mode: {0}")]
+    RawMode(io::Error),
+    #[error("failed to enter alternate screen: {0}")]
+    AlternateScreen(io::Error),
+    #[error("failed to hide cursor: {0}")]
+    HideCursor(io::Error),
+}
+
+/// Async-signal-safe restore routine: writes known ANSI sequences to
+/// stderr's raw fd.  Called from both `Drop` and the panic hook.
+///
+/// The function writes directly to fd 2 to avoid buffered-writer state
+/// that may be corrupted during a panic.
+fn restore_raw() {
+    // Byte sequences (order matters):
+    //   1. show cursor      ESC[?25h
+    //   2. reset attributes ESC[0m
+    //   3. leave alt screen ESC[?1049l
+    //   4. disable raw mode (crossterm syscall — not a write)
+    //
+    // Steps 1-3 are written as a single raw write so that even if the
+    // crossterm API isn't available (e.g. in a signal context) the
+    // sequences still reach the terminal.
+    const RESET_SEQS: &[u8] = b"\x1b[?25h\x1b[0m\x1b[?1049l";
+
+    // Write to stderr fd directly.
+    #[cfg(unix)]
+    {
+        use std::os::unix::io::FromRawFd;
+        // Safety: fd 2 is always open.
+        let mut stderr = unsafe { std::fs::File::from_raw_fd(2) };
+        let _ = stderr.write_all(RESET_SEQS);
+        let _ = stderr.flush();
+        // Do NOT drop (close) fd 2.
+        std::mem::forget(stderr);
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = io::stderr().write_all(RESET_SEQS);
+    }
+
+    // Best-effort crossterm cleanup (no-op if already disabled).
+    let _ = disable_raw_mode();
+}
+
+/// Function pointer type stored in the static.
+type RestoreFn = fn();
+
+/// Shared restore function installed once at startup.
+/// The panic hook reads this to call `restore_raw()` without holding a
+/// reference to the guard.
+static RESTORE_FN: OnceLock<RestoreFn> = OnceLock::new();
+
+/// Install the panic hook that restores the terminal.
+///
+/// Must be called once before `TerminalGuard::enter()`.  Subsequent calls
+/// are no-ops (the `OnceLock` is already set).
+pub fn install_panic_hook() {
+    RESTORE_FN.get_or_init(|| restore_raw as RestoreFn);
+
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        if let Some(f) = RESTORE_FN.get() {
+            f();
+        }
+        prev(info);
+    }));
+}
+
+/// RAII guard that owns the raw-mode + alternate-screen state.
+///
+/// Construction is via `TerminalGuard::enter()`; destruction (including
+/// on panic) is via `Drop`.
+pub struct TerminalGuard {
+    /// Tracks whether we have successfully enabled raw mode so that `Drop`
+    /// knows whether to call `disable_raw_mode`.
+    raw_enabled: bool,
+    /// Tracks whether we entered the alternate screen.
+    alt_screen: bool,
+    /// Tracks whether we hid the cursor.
+    cursor_hidden: bool,
+}
+
+impl TerminalGuard {
+    /// Enter the TUI environment: raw mode → alternate screen → hide cursor.
+    ///
+    /// On partial failure the completed steps are reversed before returning
+    /// the error so the terminal is always left in a usable state.
+    pub fn enter() -> Result<Self, TerminalError> {
+        let mut guard = TerminalGuard {
+            raw_enabled: false,
+            alt_screen: false,
+            cursor_hidden: false,
+        };
+
+        // Step 1: raw mode.
+        enable_raw_mode().map_err(|e| {
+            // Nothing to roll back yet.
+            TerminalError::RawMode(e)
+        })?;
+        guard.raw_enabled = true;
+
+        // Step 2: alternate screen.
+        execute!(io::stdout(), EnterAlternateScreen).map_err(|e| {
+            // Roll back raw mode.
+            let _ = disable_raw_mode();
+            TerminalError::AlternateScreen(e)
+        })?;
+        guard.alt_screen = true;
+
+        // Step 3: hide cursor.
+        execute!(io::stdout(), cursor::Hide).map_err(|e| {
+            // Roll back alternate screen + raw mode.
+            let _ = execute!(io::stdout(), LeaveAlternateScreen);
+            let _ = disable_raw_mode();
+            TerminalError::HideCursor(e)
+        })?;
+        guard.cursor_hidden = true;
+
+        Ok(guard)
+    }
+
+    /// Re-enter raw mode and the alternate screen after a SIGTSTP/SIGCONT
+    /// round-trip.  Idempotent — safe to call if already in the TUI.
+    pub fn re_enter(&mut self) -> io::Result<()> {
+        if !self.raw_enabled {
+            enable_raw_mode()?;
+            self.raw_enabled = true;
+        }
+        if !self.alt_screen {
+            execute!(io::stdout(), EnterAlternateScreen)?;
+            self.alt_screen = true;
+        }
+        if !self.cursor_hidden {
+            execute!(io::stdout(), cursor::Hide)?;
+            self.cursor_hidden = true;
+        }
+        Ok(())
+    }
+
+    /// Restore the terminal to its prior state without dropping the guard.
+    ///
+    /// Used by the SIGTSTP handler: restore terminal, raise SIGSTOP; on
+    /// SIGCONT call `re_enter` to come back.
+    pub fn restore(&mut self) {
+        if self.cursor_hidden {
+            let _ = execute!(io::stdout(), cursor::Show);
+            self.cursor_hidden = false;
+        }
+        if self.alt_screen {
+            let _ = execute!(io::stdout(), style::ResetColor, LeaveAlternateScreen);
+            self.alt_screen = false;
+        }
+        if self.raw_enabled {
+            let _ = disable_raw_mode();
+            self.raw_enabled = false;
+        }
+    }
+}
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        self.restore();
+    }
+}

--- a/tests/terminal_lifecycle.rs
+++ b/tests/terminal_lifecycle.rs
@@ -1,0 +1,118 @@
+/// PTY-based terminal lifecycle tests.
+///
+/// These tests spawn `blocktxt` under a PTY allocated by rexpect, send
+/// signals, and verify that the terminal is left in the correct mode.
+///
+/// The `sigtstp_restores_cooked_then_sigcont_restores_raw` test is gated
+/// to Linux only because macOS PTY semantics for SIGTSTP/SIGCONT when the
+/// controlling terminal is the master side behave differently: the slave
+/// tty does not necessarily reflect the stopped state in a way that can be
+/// reliably queried from the master side within the process-group boundary
+/// that rexpect sets up.  The other three tests run on both platforms.
+#[cfg(unix)]
+mod tests {
+    use rexpect::process::PtyProcess;
+    use std::process::Command;
+    use std::time::Duration;
+
+    // Locate the debug binary built by `cargo test`.
+    fn binary_path() -> std::path::PathBuf {
+        // CARGO_BIN_EXE_blocktxt is set by cargo test for integration tests.
+        // Fall back to a relative path for manual runs.
+        if let Ok(p) = std::env::var("CARGO_BIN_EXE_blocktxt") {
+            return p.into();
+        }
+        let mut p = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        p.push("target/debug/blocktxt");
+        p
+    }
+
+    fn spawn_blocktxt(args: &[&str]) -> PtyProcess {
+        let mut cmd = Command::new(binary_path());
+        for arg in args {
+            cmd.arg(arg);
+        }
+        PtyProcess::new(cmd).expect("failed to spawn blocktxt PTY process")
+    }
+
+    /// Helper: check that a PTY slave fd is in raw mode by querying termios
+    /// via the master side. Returns true when ICANON is NOT set (raw mode).
+    fn is_raw(proc: &PtyProcess) -> bool {
+        use nix::sys::termios::{tcgetattr, LocalFlags};
+        use std::os::fd::BorrowedFd;
+        use std::os::unix::io::AsRawFd;
+        // Safety: proc.pty is live for the duration of this call.
+        let bfd = unsafe { BorrowedFd::borrow_raw(proc.pty.as_raw_fd()) };
+        let flags = tcgetattr(bfd).expect("tcgetattr failed on PTY master");
+        !flags.local_flags.contains(LocalFlags::ICANON)
+    }
+
+    fn sleep_ms(ms: u64) {
+        std::thread::sleep(Duration::from_millis(ms));
+    }
+
+    /// After the binary starts and enters the TUI, the PTY should be in raw mode.
+    #[test]
+    fn termios_raw_after_enter() {
+        let proc = spawn_blocktxt(&[]);
+        // Give the binary time to enter raw mode (TerminalGuard::enter).
+        sleep_ms(300);
+        assert!(is_raw(&proc), "terminal should be raw after enter");
+    }
+
+    /// After sending SIGINT the binary should exit and the PTY should be
+    /// back in cooked (non-raw) mode.
+    #[test]
+    fn termios_restored_after_sigint() {
+        use nix::sys::signal::{kill, Signal};
+
+        let proc = spawn_blocktxt(&[]);
+        sleep_ms(300);
+        assert!(is_raw(&proc), "should be raw before signal");
+
+        kill(proc.child_pid, Signal::SIGINT).expect("kill SIGINT failed");
+        sleep_ms(400);
+
+        // After exit the terminal should be cooked (ICANON restored).
+        assert!(
+            !is_raw(&proc),
+            "terminal should be cooked after SIGINT exit"
+        );
+    }
+
+    /// Send SIGTSTP → PTY should go cooked; send SIGCONT → PTY should go raw
+    /// again.  Linux only — see module doc comment.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn sigtstp_restores_cooked_then_sigcont_restores_raw() {
+        use nix::sys::signal::{kill, Signal};
+
+        let proc = spawn_blocktxt(&[]);
+        sleep_ms(300);
+        assert!(is_raw(&proc), "should be raw before SIGTSTP");
+
+        kill(proc.child_pid, Signal::SIGTSTP).expect("kill SIGTSTP failed");
+        sleep_ms(400);
+        assert!(!is_raw(&proc), "should be cooked after SIGTSTP");
+
+        kill(proc.child_pid, Signal::SIGCONT).expect("kill SIGCONT failed");
+        sleep_ms(400);
+        assert!(is_raw(&proc), "should be raw again after SIGCONT");
+    }
+
+    /// `--crash-for-test` causes a panic after TerminalGuard::enter(); the
+    /// panic hook must restore the terminal before the process dies.
+    #[test]
+    fn panic_restores_terminal() {
+        let proc = spawn_blocktxt(&["--crash-for-test"]);
+        // Allow time for guard entry and the panic to fire.
+        sleep_ms(500);
+        // Process should have exited.
+        assert!(
+            proc.status().is_some(),
+            "process should have exited after panic"
+        );
+        // Terminal should be cooked.
+        assert!(!is_raw(&proc), "terminal should be cooked after panic exit");
+    }
+}


### PR DESCRIPTION
## Summary

- **`src/signals.rs`**: `Flags` struct with 5 `Arc<AtomicBool>` fields (shutdown/tstp_pending/cont_pending/winch_pending). Registered via `signal-hook::flag::register`. Handlers do `AtomicBool::store` only — no terminal I/O, async-signal-safe by design.
- **`src/terminal.rs`**: `TerminalGuard` with ordered `enter()` (raw mode → alternate screen → hide cursor) and rollback on partial failure. `Drop`/`restore()` are idempotent. Panic hook installed via `static OnceLock<fn()>` — writes raw ANSI reset bytes to fd 2, no guard reference needed.
- **`src/main.rs`**: panic hook and signal flags installed before `TerminalGuard::enter()`. Run-loop skeleton (Sprint 1 stub) observes flags each tick: `shutdown`→exit, `tstp_pending`→`restore()`+`raise(SIGSTOP)`+`re_enter()`, `cont_pending`→`re_enter()`, `winch_pending`→stub. Polls crossterm events at 8 ms per SPEC §4. Hidden `--crash-for-test` flag panics after guard entry.
- **`tests/terminal_lifecycle.rs`**: 4 rexpect PTY tests using `nix` (explicit dev-dep) + the existing rexpect transitive dep.

## Test plan

- [ ] `termios_raw_after_enter` — spawns binary, waits 300 ms, checks PTY termios ICANON not set. Runs on macOS + Linux.
- [ ] `termios_restored_after_sigint` — sends SIGINT, waits 400 ms, checks ICANON restored. Runs on macOS + Linux.
- [ ] `sigtstp_restores_cooked_then_sigcont_restores_raw` — SIGTSTP → cooked; SIGCONT → raw. **Linux only** (`#[cfg(target_os = "linux")]`). macOS PTY SIGTSTP/SIGCONT semantics don't reliably expose termios state changes on the master side that rexpect holds.
- [ ] `panic_restores_terminal` — `--crash-for-test` panics after enter, verify exit + cooked terminal. Runs on macOS + Linux.
- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `bash scripts/check-naming.sh` passes
- [ ] All tests green on CI (ubuntu + macos)

Closes #3