### PR TITLE
feat(cli): clap args + reset-scores prompt (#4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,10 +126,12 @@ dependencies = [
  "directories",
  "insta",
  "nix",
+ "predicates",
  "proptest",
  "rand",
  "rand_chacha",
  "ratatui",
+ "regex",
  "rexpect",
  "serde",
  "serde_json",
@@ -432,6 +434,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -675,6 +686,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -747,7 +764,10 @@ checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
 dependencies = [
  "anstyle",
  "difflib",
+ "float-cmp",
+ "normalize-line-endings",
  "predicates-core",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,7 @@ thiserror = "2.0.18"
 assert_cmd = "2.1.2"
 insta = "1.47.2"
 nix = { version = "0.31", features = ["signal", "term"] }
+predicates = "3"
 proptest = "1.8.0"
+regex = "1"
 rexpect = "0.6.3"

--- a/scripts/check-naming.sh
+++ b/scripts/check-naming.sh
@@ -1,16 +1,19 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 IFS=$'\n\t'
-# Stub: grep prohibited product-naming strings from README + Cargo.toml.
-# Issue #4 will extend this to release artifacts.
+# Prohibited product-name strings in README + Cargo.toml + built artifacts.
 fail=0
-for f in README.md Cargo.toml; do
-  [[ -f "$f" ]] || continue
-  # Allow "Tetris®" in trademark footer; flag bare "Tetris" otherwise
-  if grep -nE '(^|[^®a-zA-Z])Tetris([^®]|$)' "$f" \
-    | grep -vi "trademark of"; then
-    echo "::error::prohibited 'Tetris' usage in $f" >&2
+targets=(README.md Cargo.toml)
+[[ -f target/release/blocktxt ]] && targets+=(target/release/blocktxt)
+for f in "${targets[@]}"; do
+  [[ -f "${f}" ]] || continue
+  # "Tetris®" in the trademark footer is allowed; bare "Tetris" as a
+  # product name is not. The inner grep filters out lines that contain
+  # "trademark of" (the standard footer phrasing).
+  if grep -nE '(^|[^®a-zA-Z])Tetris([^®]|$)' "${f}" \
+    | grep -vi 'trademark of'; then
+    echo "::error::prohibited 'Tetris' usage in ${f}" >&2
     fail=1
   fi
 done
-exit "$fail"
+exit "${fail}"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,86 @@
+/// CLI argument definitions and pre-TTY handlers.
+///
+/// `Args` is parsed by clap (derive) before any terminal manipulation.
+/// Flags that must run before `TerminalGuard::enter()` (e.g. `--reset-scores`)
+/// are handled here in cooked mode so that no raw-mode / alternate-screen
+/// bytes leak into stdout.
+use std::io::{self, BufRead, Write};
+
+use clap::Parser;
+
+/// blocktxt — terminal falling-block puzzle game.
+///
+/// A Guideline-inspired falling-block puzzle game for macOS and Linux.
+/// Single-player, keyboard-controlled, no network, no sound.
+///
+/// For trademark information see <https://github.com/NikolayS/tetris-tui-1>.
+#[derive(Parser, Debug)]
+#[command(
+    name = "blocktxt",
+    version,
+    about = "Terminal falling-block puzzle game"
+)]
+pub struct Args {
+    /// Seed the ChaCha RNG for reproducible piece sequences.
+    ///
+    /// Accepts any u64 value. Used by Sprint 2 piece-bag generation.
+    #[arg(long)]
+    pub seed: Option<u64>,
+
+    /// Force-disable color output (supplements the NO_COLOR env variable).
+    #[arg(long)]
+    pub no_color: bool,
+
+    /// Prompt in cooked mode to delete the high-score file, then exit.
+    ///
+    /// Runs before raw mode / alternate screen so no ANSI escape bytes
+    /// appear in stdout.
+    #[arg(long)]
+    pub reset_scores: bool,
+
+    /// Trigger a panic after TerminalGuard::enter() for PTY signal tests.
+    ///
+    /// Hidden from help output. Replaces the ad-hoc args() check from PR #8.
+    #[arg(long, hide = true)]
+    pub crash_for_test: bool,
+}
+
+/// Parse command-line arguments.
+pub fn parse() -> Args {
+    Args::parse()
+}
+
+/// Handle `--reset-scores` in cooked mode before the TUI guard is entered.
+///
+/// Prompts on stdout/stdin (no ANSI sequences). If the user answers `y`
+/// or `yes` (case-insensitive), deletes the high-score file. Exits before
+/// `TerminalGuard::enter()` regardless of the answer.
+///
+/// # Cooked-mode contract (SPEC §1a / §5)
+///
+/// This function must not write any ANSI escape bytes (`\x1b`) to stdout.
+/// Tests assert this by scanning captured stdout bytes.
+pub fn handle_reset_scores(_args: &Args) -> anyhow::Result<()> {
+    // Write prompt to stdout — plain text only, no ANSI sequences.
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
+    write!(out, "Reset high scores? [y/N] ")?;
+    out.flush()?;
+
+    // Read one line from stdin in cooked mode.
+    let stdin = io::stdin();
+    let mut line = String::new();
+    stdin.lock().read_line(&mut line)?;
+
+    let answer = line.trim().to_lowercase();
+    if answer == "y" || answer == "yes" {
+        // TODO(Sprint 2): actually delete the high-score file when
+        // persistence exists. For now there is no file to delete;
+        // we acknowledge the request and exit cleanly.
+        writeln!(out, "High scores reset.")?;
+    } else {
+        writeln!(out, "Aborted.")?;
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod cli;
 mod signals;
 mod terminal;
 
@@ -8,26 +9,34 @@ use crossterm::event;
 use terminal::{install_panic_hook, TerminalGuard};
 
 fn main() -> anyhow::Result<()> {
-    // Install the panic hook BEFORE guard setup so the terminal is restored
-    // even if setup panics.
+    // Step 1: Parse CLI args (clap derive).
+    let args = cli::parse();
+
+    // Step 2: Handle --reset-scores in cooked mode before any raw mode.
+    if args.reset_scores {
+        cli::handle_reset_scores(&args)?;
+        return Ok(());
+    }
+
+    // Step 3: Install signal flags BEFORE guard enter so Ctrl-C works if
+    //         guard setup fails partway through.
+    // Step 4: Install the panic hook BEFORE guard setup so the terminal is
+    //         restored even if setup panics.
     install_panic_hook();
 
-    // Hidden flag used by PTY tests: panic immediately after guard entry to
-    // verify that the panic hook restores the terminal.  Issue #4 will
-    // replace the args() check with a proper clap subcommand.
-    let crash_for_test = std::env::args().any(|a| a == "--crash-for-test");
-
-    // Install signal flags BEFORE guard enter so Ctrl-C works if guard
-    // setup fails partway through.
     #[cfg(unix)]
     let flags = signals::unix::install()?;
 
+    // Step 5: Enter TUI (raw mode + alternate screen + hide cursor).
     let mut guard = TerminalGuard::enter()?;
 
-    if crash_for_test {
+    // Step 6: --crash-for-test panics after guard entry (used by PTY tests).
+    //         Replaces the ad-hoc std::env::args() check from PR #8.
+    if args.crash_for_test {
         panic!("--crash-for-test: intentional panic after guard entry");
     }
 
+    // Step 7: Run loop (Sprint 1 stub; real game in Sprint 2).
     run_loop(&mut guard, &flags)?;
 
     Ok(())
@@ -58,7 +67,7 @@ fn run_loop(guard: &mut TerminalGuard, flags: &signals::unix::Flags) -> anyhow::
         if flags.tstp_pending.swap(false, Ordering::Relaxed) {
             // Restore terminal before stopping so the shell gets a sane tty.
             guard.restore();
-            // Raise SIGSTOP to actually pause the process.  The kernel will
+            // Raise SIGSTOP to actually pause the process. The kernel will
             // deliver SIGCONT later when the user does `fg`.
             let _ = signal::raise(Signal::SIGSTOP);
             // When we wake from SIGSTOP (SIGCONT delivered), re-enter TUI.

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,109 @@
+/// CLI integration tests (assert_cmd).
+///
+/// Red-green TDD: these tests are written before the implementation.
+/// Each test exercises a contract from SPEC §4 "CLI flags".
+use assert_cmd::Command;
+use predicates::str::is_match;
+use regex::Regex;
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+fn cmd() -> Command {
+    Command::cargo_bin("blocktxt").expect("binary not found")
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────
+
+/// `blocktxt --version` exits 0 and prints a semver on stdout.
+#[test]
+fn version_flag_prints_crate_version() {
+    cmd()
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(is_match(r"blocktxt \d+\.\d+\.\d+\n").unwrap());
+}
+
+/// `blocktxt --help` must not use the word "Tetris" as a product name.
+///
+/// The trademark footer pattern ("trademark of") is the only allowed
+/// exception; since --help content is composed entirely by clap from the
+/// `about` string, and we control that string, there should be zero
+/// occurrences of bare "Tetris" in the help output.
+#[test]
+fn help_does_not_mention_tetris_as_product() {
+    let output = cmd().arg("--help").output().expect("failed to run --help");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // For each line, check if it contains bare "Tetris" without ® suffix,
+    // and isn't a trademark-of disclaimer line.
+    let bare_tetris_re = Regex::new(r"(?:^|[^®a-zA-Z])Tetris([^®]|$)").unwrap();
+
+    for line in stdout.lines() {
+        let lower = line.to_lowercase();
+        if lower.contains("trademark of") || lower.contains("registered trademark") {
+            // Trademark disclaimer lines are allowed to mention Tetris®.
+            continue;
+        }
+        assert!(
+            !bare_tetris_re.is_match(line),
+            "help output contains bare 'Tetris' product name on line: {line:?}"
+        );
+    }
+
+    assert!(output.status.success());
+}
+
+/// `blocktxt --reset-scores` with `n\n` on stdin exits 0 with no ANSI
+/// escape bytes in stdout (cooked-mode requirement: no raw-mode artifacts).
+#[test]
+fn reset_scores_aborts_cleanly_on_no() {
+    let output = cmd()
+        .arg("--reset-scores")
+        .write_stdin("n\n")
+        .output()
+        .expect("failed to run --reset-scores");
+
+    let stdout_bytes = &output.stdout;
+
+    // No ANSI escape sequences (\x1b) allowed in pre-TTY cooked-mode output.
+    assert!(
+        !stdout_bytes.contains(&0x1b),
+        "stdout must not contain ANSI escape bytes in cooked-mode prompt"
+    );
+
+    assert!(
+        output.status.success(),
+        "exit code should be 0 when user answers 'n'"
+    );
+}
+
+/// `blocktxt --reset-scores` with `y\n` on stdin exits 0.
+///
+/// Stub behavior for v0.1: there is no high-score file yet (Sprint 2 adds
+/// persistence). The test verifies only that the prompt is accepted and the
+/// process exits cleanly.
+///
+/// TODO(Sprint 2): actually delete the high-score file when persistence exists.
+#[test]
+fn reset_scores_exits_cleanly_on_yes() {
+    let output = cmd()
+        .arg("--reset-scores")
+        .write_stdin("y\n")
+        .output()
+        .expect("failed to run --reset-scores with y");
+
+    let stdout_bytes = &output.stdout;
+
+    // Cooked-mode prompt must not emit ANSI escape bytes.
+    assert!(
+        !stdout_bytes.contains(&0x1b),
+        "stdout must not contain ANSI escape bytes in cooked-mode prompt"
+    );
+
+    assert!(
+        output.status.success(),
+        "exit code should be 0 when user answers 'y'"
+    );
+}


### PR DESCRIPTION
## Summary

- Add `src/cli.rs` with clap derive `Args`: `--seed <u64>`, `--no-color`, `--reset-scores`, `--crash-for-test` (hidden), plus clap-auto `--version`/`--help` with a custom `about` that avoids bare "Tetris" as a product name.
- Integrate into `src/main.rs` per SPEC §4's 7-step order: parse → pre-TTY handler → signals → panic hook → `TerminalGuard::enter()` → crash-for-test check → run loop.
- `--reset-scores` runs in cooked mode (before raw mode); stdout has zero ANSI escape bytes (`\x1b`) satisfying the §1a / §5 pre-TTY contract. File deletion is a stub with `// TODO(Sprint 2)` since persistence doesn't exist yet.
- Replace the PR #2 stub in `scripts/check-naming.sh` with the real check covering `README.md`, `Cargo.toml`, and `target/release/blocktxt` (when present). Existing CI `naming-check` job already runs it.
- Add `tests/cli.rs` (assert_cmd, red-first TDD): `version_flag_prints_crate_version`, `help_does_not_mention_tetris_as_product`, `reset_scores_aborts_cleanly_on_no`, `reset_scores_exits_cleanly_on_yes`.
- Add `predicates` and `regex` to `[dev-dependencies]`.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` — all 7 tests pass (4 new CLI tests + 3 existing terminal lifecycle tests)
- [x] `bash scripts/check-naming.sh` passes
- [ ] CI green on ubuntu + macos (PR will run matrix)

Closes #4