### PR TITLE
feat(persist): hardened store + Clock (#13)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/NikolayS/tetris-tui-1"
 anyhow = "1.0.102"
 clap = { version = "4.5.61", features = ["derive"] }
 crossterm = "0.29.0"
-nix = { version = "0.31", features = ["signal"] }
+nix = { version = "0.31", features = ["signal", "user"] }
 directories = "6.0.0"
 rand = "0.9.4"
 rand_chacha = "0.9.0"

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -1,0 +1,66 @@
+//! Monotonic clock abstraction (SPEC §3).
+//!
+//! `RealClock` wraps `Instant::now()` for production use.
+//! `FakeClock` provides deterministic, thread-safe time control for tests.
+//!
+//! **Never use `SystemTime`** for game timing — `Instant` is monotonic;
+//! `SystemTime` can go backwards.
+
+use std::{
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
+
+// ── trait ─────────────────────────────────────────────────────────────────
+
+/// Monotonic clock used by the game loop.
+///
+/// `Send + Sync` so it can be shared across threads (e.g. input thread
+/// and render thread both reading the same clock).
+pub trait Clock: Send + Sync {
+    /// Returns the current monotonic instant.
+    fn now(&self) -> Instant;
+}
+
+// ── real clock ────────────────────────────────────────────────────────────
+
+/// Production clock — delegates straight to `Instant::now()`.
+pub struct RealClock;
+
+impl Clock for RealClock {
+    fn now(&self) -> Instant {
+        Instant::now()
+    }
+}
+
+// ── fake clock ────────────────────────────────────────────────────────────
+
+/// Deterministic clock for testing.
+///
+/// All clones / Arc-wrapped copies share the same underlying time, so
+/// advancing from one handle is immediately visible on all others.
+#[derive(Clone)]
+pub struct FakeClock {
+    t: Arc<Mutex<Instant>>,
+}
+
+impl FakeClock {
+    /// Creates a new `FakeClock` starting at `start`.
+    pub fn new(start: Instant) -> Self {
+        Self {
+            t: Arc::new(Mutex::new(start)),
+        }
+    }
+
+    /// Advances the fake clock by `d`.
+    pub fn advance(&self, d: Duration) {
+        let mut guard = self.t.lock().expect("FakeClock mutex poisoned");
+        *guard += d;
+    }
+}
+
+impl Clock for FakeClock {
+    fn now(&self) -> Instant {
+        *self.t.lock().expect("FakeClock mutex poisoned")
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,3 @@
+pub mod clock;
 pub mod game;
+pub mod persistence;

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -1,0 +1,342 @@
+//! Hardened high-score persistence.
+//!
+//! Security model (SPEC §4 round-2):
+//! - Directory must be owned by current user, not world-writable,
+//!   and must not be a symlink.
+//! - Files are written atomically via a same-directory temp file
+//!   (same mount point guarantees rename(2) atomicity).
+//! - Corrupt files are renamed to time-stamped backups; at most 5
+//!   backups are kept.
+
+use std::{
+    fs::{self, File},
+    io,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use directories::ProjectDirs;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+// ── error type ────────────────────────────────────────────────────────────
+
+#[derive(Debug, Error)]
+pub enum PersistenceError {
+    #[error("cannot determine home directory")]
+    NoHome,
+    #[error("data directory is a symlink — refusing (possible attack)")]
+    UnsafeSymlink,
+    #[error("data directory is world-writable — refusing")]
+    WorldWritable,
+    #[error("data directory is owned by another user")]
+    WrongOwner,
+    #[error("I/O error: {0}")]
+    Io(#[from] io::Error),
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+// ── data types ────────────────────────────────────────────────────────────
+
+/// A single high-score entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HighScore {
+    pub name: String,
+    pub score: u32,
+    pub level: u8,
+    pub lines: u32,
+    /// Unix timestamp (seconds) when the score was recorded.
+    pub ts: u64,
+}
+
+/// In-memory store of high scores, ordered descending by `score`.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct HighScoreStore {
+    scores: Vec<HighScore>,
+}
+
+impl HighScoreStore {
+    /// Creates an empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the top `n` scores (already sorted descending).
+    pub fn top(&self, n: usize) -> &[HighScore] {
+        let end = n.min(self.scores.len());
+        &self.scores[..end]
+    }
+
+    /// Inserts a score in sorted position.
+    ///
+    /// Returns `true` if this is a new personal best for the name
+    /// (i.e. it is the highest score that name has ever recorded in
+    /// this store).
+    pub fn insert(&mut self, score: HighScore) -> bool {
+        let name = score.name.clone();
+        let new_score = score.score;
+
+        // Find previous best for this name.
+        let prev_best = self
+            .scores
+            .iter()
+            .filter(|s| s.name == name)
+            .map(|s| s.score)
+            .max()
+            .unwrap_or(0);
+
+        // Insert in descending order.
+        let pos = self.scores.partition_point(|s| s.score >= score.score);
+        self.scores.insert(pos, score);
+
+        new_score > prev_best
+    }
+}
+
+// ── directory hardening ───────────────────────────────────────────────────
+
+/// Returns (creating if necessary) the hardened data directory.
+///
+/// Errors on symlink, world-writable dir, or wrong owner.
+pub fn init_data_dir() -> Result<PathBuf, PersistenceError> {
+    let dirs = ProjectDirs::from("", "", "blocktxt").ok_or(PersistenceError::NoHome)?;
+    let data_dir = dirs.data_local_dir();
+
+    if !data_dir.exists() {
+        create_dir_mode_0700(data_dir)?;
+        return Ok(data_dir.canonicalize()?);
+    }
+
+    // Directory exists — harden-check it.
+    check_dir_safety(data_dir)?;
+    Ok(data_dir.canonicalize()?)
+}
+
+/// Creates a directory (and all parents) with mode 0o700 on Unix.
+pub fn create_dir_mode_0700(path: &Path) -> Result<(), PersistenceError> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        fs::DirBuilder::new()
+            .recursive(true)
+            .mode(0o700)
+            .create(path)
+            .map_err(PersistenceError::Io)
+    }
+    #[cfg(not(unix))]
+    {
+        fs::create_dir_all(path).map_err(PersistenceError::Io)
+    }
+}
+
+/// Checks that `path` is safe to use as a data directory.
+///
+/// Returns `Ok(())` if and only if:
+/// - It is not a symlink.
+/// - It is not world-writable (Unix only).
+/// - It is owned by the current user (Unix only).
+pub fn check_dir_safety(path: &Path) -> Result<(), PersistenceError> {
+    // 1. Symlink check — use symlink_metadata so we do NOT follow links.
+    let meta = path.symlink_metadata().map_err(PersistenceError::Io)?;
+
+    if meta.file_type().is_symlink() {
+        return Err(PersistenceError::UnsafeSymlink);
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+
+        // 2. World-writable check.
+        if meta.mode() & 0o002 != 0 {
+            return Err(PersistenceError::WorldWritable);
+        }
+
+        // 3. Owner check.
+        let uid = nix::unistd::getuid().as_raw();
+        if meta.uid() != uid {
+            return Err(PersistenceError::WrongOwner);
+        }
+    }
+
+    Ok(())
+}
+
+// ── save ──────────────────────────────────────────────────────────────────
+
+/// The canonical file name inside the data directory.
+const SCORES_FILE: &str = "scores.json";
+
+/// Returns the canonical path of the scores file given the data dir.
+pub fn scores_path(dir: &Path) -> PathBuf {
+    dir.join(SCORES_FILE)
+}
+
+/// Atomically writes `store` to `<dir>/scores.json`.
+///
+/// Steps:
+/// 1. Create a temp file in the same directory (same mount point).
+/// 2. Write JSON.
+/// 3. fsync the temp file.
+/// 4. Chmod 0o600 (Unix).
+/// 5. Atomic rename via `tempfile::persist`.
+/// 6. fsync the parent directory (Unix, best-effort).
+pub fn save(store: &HighScoreStore, dir: &Path) -> Result<(), PersistenceError> {
+    let dest = scores_path(dir);
+
+    // Step 1 — temp file in the same directory.
+    let mut tmp = tempfile::NamedTempFile::new_in(dir).map_err(PersistenceError::Io)?;
+
+    // Step 2 — write JSON.
+    serde_json::to_writer_pretty(&mut tmp, store).map_err(PersistenceError::Json)?;
+
+    // Step 3 — fsync temp file.
+    tmp.as_file().sync_all().map_err(PersistenceError::Io)?;
+
+    // Step 4 — chmod 0o600 (Unix only).
+    #[cfg(unix)]
+    set_mode_0600(tmp.path())?;
+
+    // Step 5 — atomic rename.
+    tmp.persist(&dest)
+        .map_err(|e| PersistenceError::Io(e.error))?;
+
+    // Step 6 — fsync parent directory (best-effort on Unix).
+    #[cfg(unix)]
+    {
+        if let Ok(parent) = File::open(dir) {
+            let _ = parent.sync_all();
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_mode_0600(path: &Path) -> Result<(), PersistenceError> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600)).map_err(PersistenceError::Io)
+}
+
+// ── load ──────────────────────────────────────────────────────────────────
+
+/// Loads the high-score store from `<dir>/scores.json`.
+///
+/// If the file does not exist, returns an empty store.
+/// If parsing fails, renames the corrupt file to a timestamped backup,
+/// prunes backups beyond 5, and returns an empty store.
+pub fn load(dir: &Path) -> Result<HighScoreStore, PersistenceError> {
+    let path = scores_path(dir);
+
+    if !path.exists() {
+        return Ok(HighScoreStore::new());
+    }
+
+    let content = fs::read_to_string(&path).map_err(PersistenceError::Io)?;
+
+    match serde_json::from_str::<HighScoreStore>(&content) {
+        Ok(store) => Ok(store),
+        Err(_) => {
+            // Rename the corrupt file to a timestamped backup.
+            let backup = unique_corrupt_path(&path);
+            if let Err(e) = fs::rename(&path, &backup) {
+                eprintln!(
+                    "blocktxt: warning: could not rename corrupt \
+                     scores file: {e}"
+                );
+            } else {
+                eprintln!(
+                    "blocktxt: warning: scores file was corrupt; \
+                     renamed to {}",
+                    backup.display()
+                );
+            }
+
+            // Prune old backups — keep at most 5.
+            prune_corrupt_backups(&path);
+
+            Ok(HighScoreStore::new())
+        }
+    }
+}
+
+/// Returns a path like `<base>.corrupt.<ts>`, guaranteeing it does not
+/// already exist.  If a collision occurs at second granularity, a
+/// nanosecond suffix is appended.
+pub fn unique_corrupt_path(base: &Path) -> PathBuf {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = now.as_secs();
+    let nanos = now.subsec_nanos();
+
+    // Build the parent stem: "<base>.corrupt"
+    let stem = format!("{}.corrupt", base.display());
+
+    let candidate = PathBuf::from(format!("{stem}.{secs}"));
+    if !candidate.exists() {
+        return candidate;
+    }
+
+    // Collision — append nanoseconds.
+    PathBuf::from(format!("{stem}.{secs}-{nanos}"))
+}
+
+/// Keeps at most 5 `.corrupt.*` backups, deleting the oldest by mtime.
+fn prune_corrupt_backups(base: &Path) {
+    let dir = match base.parent() {
+        Some(d) => d,
+        None => return,
+    };
+    let file_stem = match base.file_name().and_then(|n| n.to_str()) {
+        Some(s) => s.to_owned(),
+        None => return,
+    };
+    let prefix = format!("{file_stem}.corrupt.");
+
+    let mut backups: Vec<(std::time::SystemTime, PathBuf)> = fs::read_dir(dir)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter_map(|e| {
+            let p = e.path();
+            let name = p.file_name()?.to_str()?.to_owned();
+            if !name.starts_with(&prefix) {
+                return None;
+            }
+            let mtime = p.metadata().ok()?.modified().ok()?;
+            Some((mtime, p))
+        })
+        .collect();
+
+    if backups.len() <= 5 {
+        return;
+    }
+
+    // Sort ascending by mtime — oldest first.
+    backups.sort_by_key(|(t, _)| *t);
+
+    let to_delete = backups.len() - 5;
+    for (_, path) in backups.iter().take(to_delete) {
+        let _ = fs::remove_file(path);
+    }
+}
+
+// ── fallback constructor ──────────────────────────────────────────────────
+
+impl HighScoreStore {
+    /// Attempts to load the store; on any error returns an empty store
+    /// plus the error so the caller can log a degraded-mode warning.
+    pub fn new_with_fallback(
+        dir_result: Result<PathBuf, PersistenceError>,
+    ) -> (Self, Option<PersistenceError>) {
+        match dir_result {
+            Err(e) => (Self::new(), Some(e)),
+            Ok(dir) => match load(&dir) {
+                Ok(store) => (store, None),
+                Err(e) => (Self::new(), Some(e)),
+            },
+        }
+    }
+}

--- a/tests/clock.rs
+++ b/tests/clock.rs
@@ -1,0 +1,54 @@
+//! Tests for `clock.rs` — monotonic Clock trait.
+
+use blocktxt::clock::{Clock, FakeClock, RealClock};
+use std::time::{Duration, Instant};
+
+// ── RealClock ─────────────────────────────────────────────────────────────
+
+/// Two successive `now()` calls on `RealClock` must be monotonically
+/// non-decreasing.
+#[test]
+fn real_clock_advances_monotonically() {
+    let clock = RealClock;
+    let t1 = clock.now();
+    let t2 = clock.now();
+    assert!(t2 >= t1, "time went backwards: {t2:?} < {t1:?}");
+}
+
+// ── FakeClock ─────────────────────────────────────────────────────────────
+
+/// `advance` on a `FakeClock` must shift `now()` by exactly the given
+/// duration.
+#[test]
+fn fake_clock_advance_deterministic() {
+    let start = Instant::now();
+    let clock = FakeClock::new(start);
+
+    assert_eq!(clock.now(), start);
+
+    clock.advance(Duration::from_secs(1));
+    assert_eq!(clock.now(), start + Duration::from_secs(1));
+
+    clock.advance(Duration::from_millis(500));
+    assert_eq!(clock.now(), start + Duration::from_millis(1500));
+}
+
+/// Advancing from a background thread must be visible on the main thread.
+#[test]
+fn fake_clock_shared_across_threads() {
+    let start = Instant::now();
+    let clock = FakeClock::new(start);
+    let clock2 = clock.clone();
+
+    let handle = std::thread::spawn(move || {
+        clock2.advance(Duration::from_secs(42));
+    });
+
+    handle.join().expect("thread panicked");
+
+    assert_eq!(
+        clock.now(),
+        start + Duration::from_secs(42),
+        "advance from thread not visible on main thread"
+    );
+}

--- a/tests/persistence.rs
+++ b/tests/persistence.rs
@@ -1,0 +1,264 @@
+//! Integration tests for `persistence.rs`.
+//!
+//! Security-critical paths (symlink, world-writable, mode) are gated
+//! with `#[cfg(unix)]` or `#[cfg_attr(not(unix), ignore)]`.
+
+use blocktxt::persistence::{
+    self, check_dir_safety, create_dir_mode_0700, HighScore, HighScoreStore, PersistenceError,
+};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+use tempfile::TempDir;
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+fn make_score(name: &str, score: u32) -> HighScore {
+    HighScore {
+        name: name.to_owned(),
+        score,
+        level: 1,
+        lines: 10,
+        ts: 0,
+    }
+}
+
+fn data_dir(tmp: &TempDir) -> PathBuf {
+    tmp.path().join("data")
+}
+
+// ── directory hardening ───────────────────────────────────────────────────
+
+/// `create_dir_mode_0700` must produce a directory with mode 0o700 on Unix.
+#[test]
+#[cfg(unix)]
+fn init_data_dir_creates_with_0o700() {
+    use std::os::unix::fs::MetadataExt;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().join("newdir");
+
+    create_dir_mode_0700(&dir).expect("should create dir");
+
+    let meta = fs::metadata(&dir).unwrap();
+    let mode = meta.mode() & 0o777;
+    assert_eq!(mode, 0o700, "expected mode 0o700, got 0o{mode:o}");
+}
+
+/// `check_dir_safety` must refuse a symlink.
+#[test]
+#[cfg(unix)]
+fn init_data_dir_refuses_symlink() {
+    use std::os::unix::fs as unix_fs;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let real_dir = tmp.path().join("real");
+    let link = tmp.path().join("link");
+    fs::create_dir(&real_dir).unwrap();
+    unix_fs::symlink(&real_dir, &link).unwrap();
+
+    let err = check_dir_safety(&link).unwrap_err();
+    assert!(
+        matches!(err, PersistenceError::UnsafeSymlink),
+        "unexpected error: {err}"
+    );
+}
+
+/// `check_dir_safety` must refuse a world-writable directory.
+#[test]
+#[cfg(unix)]
+fn init_data_dir_refuses_world_writable() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().join("public");
+    fs::create_dir(&dir).unwrap();
+    fs::set_permissions(&dir, fs::Permissions::from_mode(0o777)).unwrap();
+
+    let err = check_dir_safety(&dir).unwrap_err();
+    assert!(
+        matches!(err, PersistenceError::WorldWritable),
+        "unexpected error: {err}"
+    );
+}
+
+// ── save / load roundtrip ─────────────────────────────────────────────────
+
+#[test]
+fn save_then_load_roundtrip() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = data_dir(&tmp);
+    create_dir_mode_0700(&dir).unwrap();
+
+    let mut store = HighScoreStore::new();
+    store.insert(make_score("Alice", 1000));
+    store.insert(make_score("Bob", 500));
+
+    persistence::save(&store, &dir).expect("save should succeed");
+
+    let loaded = persistence::load(&dir).expect("load should succeed");
+    let top = loaded.top(10);
+    assert_eq!(top.len(), 2);
+    assert_eq!(top[0].score, 1000);
+    assert_eq!(top[0].name, "Alice");
+    assert_eq!(top[1].score, 500);
+}
+
+/// Saved file must have mode 0o600 on Unix.
+#[test]
+#[cfg(unix)]
+fn save_writes_0o600() {
+    use std::os::unix::fs::MetadataExt;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = data_dir(&tmp);
+    create_dir_mode_0700(&dir).unwrap();
+
+    let store = HighScoreStore::new();
+    persistence::save(&store, &dir).unwrap();
+
+    let path = persistence::scores_path(&dir);
+    let meta = fs::metadata(&path).unwrap();
+    let mode = meta.mode() & 0o777;
+    assert_eq!(mode, 0o600, "expected 0o600, got 0o{mode:o}");
+}
+
+// ── corrupt-file recovery ─────────────────────────────────────────────────
+
+/// Writing garbage JSON then calling `load` must:
+/// - return an empty store, and
+/// - create a `.corrupt.<ts>` backup file.
+#[test]
+fn load_corrupt_renames_and_returns_empty() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = data_dir(&tmp);
+    create_dir_mode_0700(&dir).unwrap();
+
+    let scores_file = persistence::scores_path(&dir);
+    fs::write(&scores_file, b"not json at all").unwrap();
+
+    let store = persistence::load(&dir).expect("load should not propagate error");
+
+    // Store must be empty.
+    assert_eq!(store.top(10).len(), 0);
+
+    // Original file must be gone.
+    assert!(
+        !scores_file.exists(),
+        "corrupt file should have been renamed away"
+    );
+
+    // A backup with the `.corrupt.` prefix must exist.
+    let backups = find_corrupt_backups(&dir, "scores.json");
+    assert!(!backups.is_empty(), "expected a .corrupt.* backup file");
+}
+
+/// After 6 pre-existing `.corrupt.*` files a new corruption must delete
+/// the oldest, leaving exactly 5 backups.
+#[test]
+fn corrupt_backup_cap_at_5() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = data_dir(&tmp);
+    create_dir_mode_0700(&dir).unwrap();
+
+    // Create 6 pre-existing backups with timestamps 100000000..100000005.
+    // The oldest has ts=100000000.
+    for i in 0u64..=5 {
+        let p = dir.join(format!("scores.json.corrupt.{}", 100_000_000 + i));
+        fs::write(&p, b"old").unwrap();
+        // Stagger mtimes so the oldest is unambiguous.
+        // We rely on creation order; on most OSes that's sufficient.
+    }
+
+    // Force a fresh corruption.
+    let scores_file = persistence::scores_path(&dir);
+    fs::write(&scores_file, b"garbage").unwrap();
+    persistence::load(&dir).unwrap();
+
+    let backups = find_corrupt_backups(&dir, "scores.json");
+    assert_eq!(
+        backups.len(),
+        5,
+        "expected exactly 5 backups, got {}: {backups:?}",
+        backups.len()
+    );
+}
+
+/// Two corruptions that occur within the same second must produce
+/// distinct backup file names (no silent overwrite).
+#[test]
+fn no_overwrite_existing_corrupt_same_second() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = data_dir(&tmp);
+    create_dir_mode_0700(&dir).unwrap();
+
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+
+    // Plant a backup that collides with the current second.
+    let collider = dir.join(format!("scores.json.corrupt.{ts}"));
+    fs::write(&collider, b"old").unwrap();
+
+    // Now trigger a new corruption.
+    let scores_file = persistence::scores_path(&dir);
+    fs::write(&scores_file, b"also garbage").unwrap();
+    persistence::load(&dir).unwrap();
+
+    let backups = find_corrupt_backups(&dir, "scores.json");
+    // We should have at least 2 distinct backups.
+    assert!(
+        backups.len() >= 2,
+        "expected ≥2 distinct backups, got {}: {backups:?}",
+        backups.len()
+    );
+}
+
+// ── HighScoreStore logic ──────────────────────────────────────────────────
+
+#[test]
+fn insert_returns_true_for_personal_best() {
+    let mut store = HighScoreStore::new();
+    // First score for Alice is always a personal best.
+    assert!(store.insert(make_score("Alice", 100)));
+    // 50 < 100 — not a personal best.
+    assert!(!store.insert(make_score("Alice", 50)));
+    // 200 > 100 — new personal best.
+    assert!(store.insert(make_score("Alice", 200)));
+}
+
+#[test]
+fn top_n_is_sorted_descending() {
+    let mut store = HighScoreStore::new();
+    for &s in &[300u32, 100, 200, 500, 400] {
+        store.insert(make_score("Player", s));
+    }
+    let top = store.top(3);
+    assert_eq!(top.len(), 3);
+    assert_eq!(top[0].score, 500);
+    assert_eq!(top[1].score, 400);
+    assert_eq!(top[2].score, 300);
+}
+
+// ── helper ────────────────────────────────────────────────────────────────
+
+fn find_corrupt_backups(dir: &Path, base_name: &str) -> Vec<PathBuf> {
+    let prefix = format!("{base_name}.corrupt.");
+    fs::read_dir(dir)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter_map(|e| {
+            let p = e.path();
+            let name = p.file_name()?.to_str()?.to_owned();
+            if name.starts_with(&prefix) {
+                Some(p)
+            } else {
+                None
+            }
+        })
+        .collect()
+}


### PR DESCRIPTION
## Summary

- **`src/persistence.rs`**: Atomic high-score store with full directory hardening per SPEC §4 round-2. Refuses symlinks, world-writable dirs, and dirs owned by another uid. Writes via `tempfile::NamedTempFile::new_in(dir)` + `persist()` for atomic rename on the same mount point. Corrupt-file recovery renames to `<path>.corrupt.<unix_ts>` (nanosecond suffix on collision), caps at 5 backups.
- **`src/clock.rs`**: `Clock` trait (`Send+Sync`) with `RealClock` (`Instant::now()`) and `FakeClock` (`Arc<Mutex<Instant>>`) for deterministic game-loop testing. No `SystemTime` in game timing path.
- **`nix` feature bump**: added `"user"` feature for `nix::unistd::getuid()` — already a dep from PR #8, no new crate.

## Test plan

- [ ] `cargo test` — all 30 tests pass (10 new persistence, 3 new clock, 17 existing)
- [ ] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] `cargo fmt` — clean
- [ ] `bash scripts/check-naming.sh` — passes
- [ ] Unix-gated tests (`#[cfg(unix)]`): `init_data_dir_creates_with_0o700`, `init_data_dir_refuses_symlink`, `init_data_dir_refuses_world_writable`, `save_writes_0o600`
- [ ] Cross-platform tests (no cfg gate): `save_then_load_roundtrip`, `load_corrupt_renames_and_returns_empty`, `corrupt_backup_cap_at_5`, `no_overwrite_existing_corrupt_same_second`, `insert_returns_true_for_personal_best`, `top_n_is_sorted_descending`

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)