### PR TITLE
feat(srs): JLSTZ + I kicks (#11)

### DIFF
--- a/src/game/piece.rs
+++ b/src/game/piece.rs
@@ -44,17 +44,25 @@ impl Piece {
 
 /// Cell offsets (col_delta, row_delta) relative to the piece origin.
 ///
-/// Only `Rotation::Zero` is defined for Sprint 1; other rotations are
-/// Sprint 2 (srs.rs).
+/// Shape tables for all four rotation states: Zero, R, Two, L.
+/// Derived by applying 90° CW rotation to the Zero state coordinates
+/// within each piece's canonical bounding box.
+///
+/// I uses a 4×4 bounding box; O uses a 2×2 box; JLSTZ use a 3×3 box.
+/// The origin (top-left of the bounding box) is held fixed across
+/// rotation states so that kick offsets translate cleanly.
 fn shape_offsets(kind: PieceKind, rotation: Rotation) -> &'static [(i32, i32)] {
-    // Sprint 1: only Zero rotation shapes are defined.
-    // Sprint 2 will fill in R, Two, L via srs.rs.
     match rotation {
         Rotation::Zero => shape_offsets_zero(kind),
-        // Placeholder: return same shape as Zero until Sprint 2.
-        _ => shape_offsets_zero(kind),
+        Rotation::R => shape_offsets_r(kind),
+        Rotation::Two => shape_offsets_two(kind),
+        Rotation::L => shape_offsets_l(kind),
     }
 }
+
+// ---------------------------------------------------------------------------
+// Zero rotation (spawning orientation)
+// ---------------------------------------------------------------------------
 
 /// Zero-rotation cell offsets (col, row) relative to bounding-box top-left.
 ///
@@ -63,34 +71,180 @@ fn shape_offsets(kind: PieceKind, rotation: Rotation) -> &'static [(i32, i32)] {
 ///   O                 — 2-wide (cols 0..2), 2 rows.
 fn shape_offsets_zero(kind: PieceKind) -> &'static [(i32, i32)] {
     match kind {
-        // I: row 1 of the 4×2 bbox (standard Guideline Zero state)
-        //    ....
-        //    XXXX
+        // I: 4×4 bounding box. Cells in row 1 (0-indexed).
+        //    . . . .
+        //    X X X X
+        //    . . . .
+        //    . . . .
         PieceKind::I => &[(0, 1), (1, 1), (2, 1), (3, 1)],
-        // O: 2×2
-        //    XX
-        //    XX
+        // O: 2×2 bounding box.
+        //    X X
+        //    X X
         PieceKind::O => &[(0, 0), (1, 0), (0, 1), (1, 1)],
-        // T:
-        //    .X.
-        //    XXX
+        // T: 3×3 bounding box.
+        //    . X .
+        //    X X X
+        //    . . .
         PieceKind::T => &[(1, 0), (0, 1), (1, 1), (2, 1)],
-        // S:
-        //    .XX
-        //    XX.
+        // S: 3×3 bounding box.
+        //    . X X
+        //    X X .
+        //    . . .
         PieceKind::S => &[(1, 0), (2, 0), (0, 1), (1, 1)],
-        // Z:
-        //    XX.
-        //    .XX
+        // Z: 3×3 bounding box.
+        //    X X .
+        //    . X X
+        //    . . .
         PieceKind::Z => &[(0, 0), (1, 0), (1, 1), (2, 1)],
-        // J:
-        //    X..
-        //    XXX
+        // J: 3×3 bounding box.
+        //    X . .
+        //    X X X
+        //    . . .
         PieceKind::J => &[(0, 0), (0, 1), (1, 1), (2, 1)],
-        // L:
-        //    ..X
-        //    XXX
+        // L: 3×3 bounding box.
+        //    . . X
+        //    X X X
+        //    . . .
         PieceKind::L => &[(2, 0), (0, 1), (1, 1), (2, 1)],
+    }
+}
+
+// ---------------------------------------------------------------------------
+// R rotation (90° CW from Zero)
+// ---------------------------------------------------------------------------
+
+/// R-rotation cell offsets (col, row) relative to bounding-box top-left.
+///
+/// Derived by rotating Zero-state cells 90° CW within the bounding box:
+///   (col, row) → (box_rows - 1 - row, col)   [for square boxes]
+/// I box is 4×4; O box is 2×2; JLSTZ box is 3×3.
+fn shape_offsets_r(kind: PieceKind) -> &'static [(i32, i32)] {
+    match kind {
+        // I: 4×4 box. 90° CW: Zero row1 → R col2.
+        //    . . X .
+        //    . . X .
+        //    . . X .
+        //    . . X .
+        PieceKind::I => &[(2, 0), (2, 1), (2, 2), (2, 3)],
+        // O: rotation is identity (2×2 symmetric).
+        PieceKind::O => &[(0, 0), (1, 0), (0, 1), (1, 1)],
+        // T: 3×3 box. 90° CW.
+        //    . X .
+        //    . X X
+        //    . X .
+        PieceKind::T => &[(1, 0), (1, 1), (2, 1), (1, 2)],
+        // S: 3×3 box. 90° CW.
+        //    . X .
+        //    . X X
+        //    . . X
+        PieceKind::S => &[(1, 0), (1, 1), (2, 1), (2, 2)],
+        // Z: 3×3 box. 90° CW.
+        //    . . X
+        //    . X X
+        //    . X .
+        PieceKind::Z => &[(2, 0), (1, 1), (2, 1), (1, 2)],
+        // J: 3×3 box. 90° CW.
+        //    . X X
+        //    . X .
+        //    . X .
+        PieceKind::J => &[(1, 0), (2, 0), (1, 1), (1, 2)],
+        // L: 3×3 box. 90° CW.
+        //    . X .
+        //    . X .
+        //    . X X
+        PieceKind::L => &[(1, 0), (1, 1), (1, 2), (2, 2)],
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Two rotation (180° from Zero)
+// ---------------------------------------------------------------------------
+
+/// Two-rotation cell offsets (col, row) relative to bounding-box top-left.
+///
+/// Derived by rotating Zero 180° within the bounding box:
+///   (col, row) → (box_cols - 1 - col, box_rows - 1 - row)
+fn shape_offsets_two(kind: PieceKind) -> &'static [(i32, i32)] {
+    match kind {
+        // I: 4×4 box. 180°: Zero row1 → Two row2.
+        //    . . . .
+        //    . . . .
+        //    X X X X
+        //    . . . .
+        PieceKind::I => &[(0, 2), (1, 2), (2, 2), (3, 2)],
+        // O: rotation is identity.
+        PieceKind::O => &[(0, 0), (1, 0), (0, 1), (1, 1)],
+        // T: 3×3 box. 180°.
+        //    . . .
+        //    X X X
+        //    . X .
+        PieceKind::T => &[(0, 1), (1, 1), (2, 1), (1, 2)],
+        // S: 3×3 box. 180°.
+        //    . . .
+        //    . X X
+        //    X X .
+        PieceKind::S => &[(1, 1), (2, 1), (0, 2), (1, 2)],
+        // Z: 3×3 box. 180°.
+        //    . . .
+        //    X X .
+        //    . X X
+        PieceKind::Z => &[(0, 1), (1, 1), (1, 2), (2, 2)],
+        // J: 3×3 box. 180°.
+        //    . . .
+        //    X X X
+        //    . . X
+        PieceKind::J => &[(0, 1), (1, 1), (2, 1), (2, 2)],
+        // L: 3×3 box. 180°.
+        //    . . .
+        //    X X X
+        //    X . .
+        PieceKind::L => &[(0, 1), (1, 1), (2, 1), (0, 2)],
+    }
+}
+
+// ---------------------------------------------------------------------------
+// L rotation (90° CCW from Zero; equivalently 270° CW)
+// ---------------------------------------------------------------------------
+
+/// L-rotation cell offsets (col, row) relative to bounding-box top-left.
+///
+/// Derived by rotating Zero 90° CCW within the bounding box:
+///   (col, row) → (row, box_cols - 1 - col)   [for square boxes]
+fn shape_offsets_l(kind: PieceKind) -> &'static [(i32, i32)] {
+    match kind {
+        // I: 4×4 box. 90° CCW: Zero row1 → L col1.
+        //    . X . .
+        //    . X . .
+        //    . X . .
+        //    . X . .
+        PieceKind::I => &[(1, 0), (1, 1), (1, 2), (1, 3)],
+        // O: rotation is identity.
+        PieceKind::O => &[(0, 0), (1, 0), (0, 1), (1, 1)],
+        // T: 3×3 box. 90° CCW.
+        //    . X .
+        //    X X .
+        //    . X .
+        PieceKind::T => &[(1, 0), (0, 1), (1, 1), (1, 2)],
+        // S: 3×3 box. 90° CCW.
+        //    X . .
+        //    X X .
+        //    . X .
+        PieceKind::S => &[(0, 0), (0, 1), (1, 1), (1, 2)],
+        // Z: 3×3 box. 90° CCW.
+        //    . X .
+        //    X X .
+        //    X . .
+        PieceKind::Z => &[(1, 0), (0, 1), (1, 1), (0, 2)],
+        // J: 3×3 box. 90° CCW.
+        //    . X .
+        //    . X .
+        //    X X .
+        PieceKind::J => &[(1, 0), (1, 1), (0, 2), (1, 2)],
+        // L: 3×3 box. 90° CCW.
+        //    X X .
+        //    . X .
+        //    . X .
+        PieceKind::L => &[(0, 0), (1, 0), (1, 1), (1, 2)],
     }
 }
 

--- a/src/game/srs.rs
+++ b/src/game/srs.rs
@@ -1,4 +1,5 @@
-use crate::game::piece::Piece;
+use crate::game::board::Board;
+use crate::game::piece::{Piece, PieceKind, Rotation};
 
 /// Rotation direction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -10,13 +11,206 @@ pub enum RotationDir {
 /// Errors returned by `rotate`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SrsError {
-    /// All SRS kick offsets were blocked; rotation rejected.
-    Blocked,
+    /// All five SRS kick offsets were blocked; rotation rejected.
+    BlockedAfterAllKicks,
 }
 
-/// Rotate `piece` in direction `dir` using SRS kick tables.
+// ---------------------------------------------------------------------------
+// Kick tables
+// ---------------------------------------------------------------------------
+//
+// The SRS algorithm tries up to five (col_delta, row_delta) offsets in order.
+// The first offset whose resulting piece position is collision-free is used.
+//
+// Two separate tables are defined:
+//   JLSTZ_KICKS — used for J, L, S, T, Z pieces.
+//   I_KICKS     — used for the I piece (wider bounding box, different offsets).
+//
+// Each table is indexed by [from_state][direction]:
+//   Axis 0: from_state in {Zero=0, R=1, Two=2, L=3}.
+//   Axis 1: direction in {Cw=0, Ccw=1}.
+//   Value: array of 5 (col_delta, row_delta) offsets.
+//
+// Derivation:
+//   Each offset is computed as (target_state_origin - source_state_origin)
+//   for the corresponding cell in the canonical SRS state diagrams.
+//   "Origin" here is the per-state anchor point used to align the rotated
+//   shape within the global bounding box.
+//
+//   For JLSTZ (3×3 box):
+//     Zero anchor = (0,0); R anchor = (1,0); Two anchor = (0,-1); L anchor = (-1,-1).
+//   For I (4×4 box):
+//     Zero anchor = (0,1); R anchor = (2,0); Two anchor = (-1,2); L anchor = (1,-1).
+//   The standard five test offsets for each transition are the differences
+//   between the CW-destination anchor and the source anchor, adjusted by the
+//   canonical test displacement sequence from the SRS specification.
+//
+// See §1a: offsets are encoded from the mathematical definition of SRS and
+// cross-checked against community references; we cite "Super Rotation System
+// (SRS)" as the public specification implemented here.
+
+/// JLSTZ kick offsets: [from_state][dir] → [(col_delta, row_delta); 5].
 ///
-/// Full implementation deferred to Sprint 2.
-pub fn rotate(_piece: &Piece, _dir: RotationDir) -> Result<Piece, SrsError> {
-    unimplemented!("srs::rotate — Sprint 2 (issue TBD)")
+/// Positive col_delta moves right; positive row_delta moves down
+/// (our coordinate system: origin top-left, y↓).
+///
+/// Transition encoding matches standard SRS state sequence:
+///   state 0=Zero, 1=R, 2=Two, 3=L; dir 0=CW, 1=CCW.
+///
+/// Test 0 is always (0,0); subsequent tests step through the canonical
+/// SRS displacement sequence for that transition.
+#[rustfmt::skip]
+const JLSTZ_KICKS: [[[(i32, i32); 5]; 2]; 4] = [
+    // from Zero
+    [
+        // CW  (Zero→R)
+        [(0,0), (-1,0), (-1, 1), (0,-2), (-1,-2)],
+        // CCW (Zero→L)
+        [(0,0), ( 1,0), ( 1, 1), (0,-2), ( 1,-2)],
+    ],
+    // from R
+    [
+        // CW  (R→Two)
+        [(0,0), ( 1,0), ( 1,-1), (0, 2), ( 1, 2)],
+        // CCW (R→Zero)
+        [(0,0), ( 1,0), ( 1,-1), (0, 2), ( 1, 2)],
+    ],
+    // from Two
+    [
+        // CW  (Two→L)
+        [(0,0), ( 1,0), ( 1, 1), (0,-2), ( 1,-2)],
+        // CCW (Two→R)
+        [(0,0), (-1,0), (-1, 1), (0,-2), (-1,-2)],
+    ],
+    // from L
+    [
+        // CW  (L→Zero)
+        [(0,0), (-1,0), (-1,-1), (0, 2), (-1, 2)],
+        // CCW (L→Two)
+        [(0,0), (-1,0), (-1,-1), (0, 2), (-1, 2)],
+    ],
+];
+
+/// I-piece kick offsets: [from_state][dir] → [(col_delta, row_delta); 5].
+///
+/// The I piece uses a 4×4 bounding box with its own anchor sequence
+/// derived from the SRS I-piece state definitions.
+///
+/// Test 0 is always (0,0); subsequent tests are derived from the
+/// I-piece anchor offsets: Zero=(0,1), R=(2,0), Two=(-1,2), L=(1,-1).
+#[rustfmt::skip]
+const I_KICKS: [[[(i32, i32); 5]; 2]; 4] = [
+    // from Zero
+    [
+        // CW  (Zero→R)
+        [(0,0), (-2,0), ( 1,0), (-2,-1), ( 1, 2)],
+        // CCW (Zero→L)
+        [(0,0), (-1,0), ( 2,0), (-1, 2), ( 2,-1)],
+    ],
+    // from R
+    [
+        // CW  (R→Two)
+        [(0,0), (-1,0), ( 2,0), (-1, 2), ( 2,-1)],
+        // CCW (R→Zero)
+        [(0,0), ( 2,0), (-1,0), ( 2, 1), (-1,-2)],
+    ],
+    // from Two
+    [
+        // CW  (Two→L)
+        [(0,0), ( 2,0), (-1,0), ( 2, 1), (-1,-2)],
+        // CCW (Two→R)
+        [(0,0), ( 1,0), (-2,0), ( 1,-2), (-2, 1)],
+    ],
+    // from L
+    [
+        // CW  (L→Zero)
+        [(0,0), ( 1,0), (-2,0), ( 1,-2), (-2, 1)],
+        // CCW (L→Two)
+        [(0,0), (-2,0), ( 1,0), (-2,-1), ( 1, 2)],
+    ],
+];
+
+// ---------------------------------------------------------------------------
+// Rotation state machine
+// ---------------------------------------------------------------------------
+
+fn next_rotation(current: Rotation, dir: RotationDir) -> Rotation {
+    match (current, dir) {
+        (Rotation::Zero, RotationDir::Cw) => Rotation::R,
+        (Rotation::R, RotationDir::Cw) => Rotation::Two,
+        (Rotation::Two, RotationDir::Cw) => Rotation::L,
+        (Rotation::L, RotationDir::Cw) => Rotation::Zero,
+        (Rotation::Zero, RotationDir::Ccw) => Rotation::L,
+        (Rotation::L, RotationDir::Ccw) => Rotation::Two,
+        (Rotation::Two, RotationDir::Ccw) => Rotation::R,
+        (Rotation::R, RotationDir::Ccw) => Rotation::Zero,
+    }
+}
+
+fn rotation_index(r: Rotation) -> usize {
+    match r {
+        Rotation::Zero => 0,
+        Rotation::R => 1,
+        Rotation::Two => 2,
+        Rotation::L => 3,
+    }
+}
+
+fn dir_index(dir: RotationDir) -> usize {
+    match dir {
+        RotationDir::Cw => 0,
+        RotationDir::Ccw => 1,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Collision check
+// ---------------------------------------------------------------------------
+
+/// Return true if `piece` (with the given rotation and origin) has no
+/// collisions against `board`. Out-of-bounds cells count as collisions.
+fn fits(piece: &Piece, board: &Board) -> bool {
+    piece
+        .cells()
+        .into_iter()
+        .all(|(col, row)| !board.is_occupied(col, row))
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Attempt to rotate `piece` in direction `dir` using SRS kick tables.
+///
+/// Tries up to five kick offsets in order. The first candidate position
+/// that does not collide with `board` is accepted and returned. If all
+/// five candidates collide, returns `Err(SrsError::BlockedAfterAllKicks)`.
+///
+/// The O piece always succeeds (its shape is rotationally symmetric and
+/// the kick sequence starts with (0,0) which never fails for a legally-placed
+/// piece on an open board); its rotation state still advances.
+pub fn rotate(piece: &Piece, dir: RotationDir, board: &Board) -> Result<Piece, SrsError> {
+    let target_rotation = next_rotation(piece.rotation, dir);
+    let from_idx = rotation_index(piece.rotation);
+    let dir_idx = dir_index(dir);
+
+    let kicks: &[(i32, i32); 5] = match piece.kind {
+        PieceKind::I => &I_KICKS[from_idx][dir_idx],
+        // O is symmetric — use the JLSTZ table (the (0,0) first kick always
+        // succeeds for a legally-placed piece on any reachable board state).
+        _ => &JLSTZ_KICKS[from_idx][dir_idx],
+    };
+
+    for &(kc, kr) in kicks {
+        let candidate = Piece {
+            kind: piece.kind,
+            rotation: target_rotation,
+            origin: (piece.origin.0 + kc, piece.origin.1 + kr),
+        };
+        if fits(&candidate, board) {
+            return Ok(candidate);
+        }
+    }
+
+    Err(SrsError::BlockedAfterAllKicks)
 }

--- a/tests/srs_rotation.rs
+++ b/tests/srs_rotation.rs
@@ -1,19 +1,208 @@
+use blocktxt::game::board::Board;
 use blocktxt::game::piece::{spawn, PieceKind, Rotation};
-use blocktxt::game::srs::{rotate, RotationDir};
+use blocktxt::game::srs::{rotate, RotationDir, SrsError};
 
-/// Red test — Sprint 2 will implement srs::rotate.
+/// Sprint 1 red test — now green with Sprint 2 implementation.
 ///
 /// For the I piece, the SRS Zero→R wall-kick table starts with the
 /// `(0, 0)` offset on an open board — so rotation succeeds without
-/// displacing the origin. Sprint 1's `srs::rotate` is
-/// `unimplemented!()`, so this test panics; `#[ignore]` keeps CI green
-/// until Sprint 2.
+/// displacing the origin.
 #[test]
-#[ignore = "red: Sprint 2 will implement srs::rotate"]
 fn srs_i_rotation_clockwise_applies_kick_offset() {
     let piece = spawn(PieceKind::I);
-    let rotated = rotate(&piece, RotationDir::Cw).expect("rotation ok");
+    let board = Board::empty();
+    let rotated = rotate(&piece, RotationDir::Cw, &board).expect("rotation ok");
     assert_eq!(rotated.rotation, Rotation::R);
     // I Zero→R: (0, 0) kick on an open board — origin does not move.
     assert_eq!(rotated.origin, piece.origin);
+}
+
+/// Any JLSTZ piece on an open board uses the (0,0) kick (first in the table)
+/// when rotating Zero→R.
+#[test]
+fn srs_jlstz_open_board_zero_to_r_uses_0_0_kick() {
+    let board = Board::empty();
+    for kind in [
+        PieceKind::J,
+        PieceKind::L,
+        PieceKind::S,
+        PieceKind::T,
+        PieceKind::Z,
+    ] {
+        let piece = spawn(kind);
+        let rotated = rotate(&piece, RotationDir::Cw, &board)
+            .unwrap_or_else(|_| panic!("{kind:?} Zero→R should succeed on open board"));
+        assert_eq!(
+            rotated.rotation,
+            Rotation::R,
+            "{kind:?} should reach state R"
+        );
+        // (0,0) kick — origin unchanged.
+        assert_eq!(
+            rotated.origin, piece.origin,
+            "{kind:?} open-board kick should be (0,0)"
+        );
+    }
+}
+
+/// Z piece CW full cycle on an open board: Zero→R→2→L→Zero.
+/// After four CW rotations the rotation state returns to Zero and the
+/// origin is identical to the original (all kicks are (0,0) on open board).
+#[test]
+fn srs_jlstz_cw_full_cycle_returns_to_zero() {
+    let board = Board::empty();
+    for kind in [
+        PieceKind::J,
+        PieceKind::L,
+        PieceKind::S,
+        PieceKind::T,
+        PieceKind::Z,
+    ] {
+        let p0 = spawn(kind);
+        let p1 = rotate(&p0, RotationDir::Cw, &board)
+            .unwrap_or_else(|_| panic!("{kind:?} step 1 failed"));
+        let p2 = rotate(&p1, RotationDir::Cw, &board)
+            .unwrap_or_else(|_| panic!("{kind:?} step 2 failed"));
+        let p3 = rotate(&p2, RotationDir::Cw, &board)
+            .unwrap_or_else(|_| panic!("{kind:?} step 3 failed"));
+        let p4 = rotate(&p3, RotationDir::Cw, &board)
+            .unwrap_or_else(|_| panic!("{kind:?} step 4 failed"));
+        assert_eq!(
+            p4.rotation,
+            Rotation::Zero,
+            "{kind:?} should complete cycle back to Zero"
+        );
+        assert_eq!(
+            p4.origin, p0.origin,
+            "{kind:?} origin should be unchanged after full cycle"
+        );
+    }
+}
+
+/// I piece CCW full cycle on an open board: Zero→L→2→R→Zero.
+/// After four CCW rotations the rotation state returns to Zero.
+#[test]
+fn srs_i_ccw_full_cycle_returns_to_zero() {
+    let board = Board::empty();
+    let p0 = spawn(PieceKind::I);
+    let p1 = rotate(&p0, RotationDir::Ccw, &board).expect("I step 1 CCW");
+    let p2 = rotate(&p1, RotationDir::Ccw, &board).expect("I step 2 CCW");
+    let p3 = rotate(&p2, RotationDir::Ccw, &board).expect("I step 3 CCW");
+    let p4 = rotate(&p3, RotationDir::Ccw, &board).expect("I step 4 CCW");
+    assert_eq!(p4.rotation, Rotation::Zero, "I should return to Zero");
+    assert_eq!(
+        p4.origin, p0.origin,
+        "I origin unchanged after full CCW cycle"
+    );
+}
+
+/// Block the (0,0) kick so the piece must use the second kick (-1,0).
+///
+/// JLSTZ Zero→R kicks (col_delta, row_delta):
+///   kick 0: (0, 0)
+///   kick 1: (-1, 0)
+///   kick 2: (-1, +1)
+///   kick 3: (0, -2)
+///   kick 4: (-1, -2)
+///
+/// T in state R shape offsets from piece.rs: (1,0),(1,1),(2,1),(1,2).
+/// At origin (3,18), cells: (4,18),(4,19),(5,19),(4,20).
+/// Block those four cells → kick 0 collides.
+/// Kick 1 candidate origin (2,18): cells (3,18),(3,19),(4,19),(3,20).
+/// We also need (4,19) blocked to prevent kick 0 but must leave
+/// (3,18),(3,19),(4,19),(3,20) free — so only block (4,18),(4,20),(5,19).
+/// Together with (4,19) that blocks kick 0; kick 1 lands at (2,18) clear.
+#[test]
+fn srs_rotation_uses_first_unblocked_kick() {
+    // T in state R offsets relative to origin: (1,0),(1,1),(2,1),(1,2).
+    // Kick 0 candidate origin = spawn origin (3,18):
+    //   cells (4,18),(4,19),(5,19),(4,20) — block all four.
+    // Kick 1 candidate origin = (3-1, 18+0) = (2,18):
+    //   cells (3,18),(3,19),(4,19),(3,20) — (4,19) is blocked from above,
+    //   so kick 1 also collides.
+    // Kick 2 candidate origin = (3-1, 18+1) = (2,19):
+    //   cells (3,19),(3,20),(4,20),(3,21) — (4,20) is blocked → collides.
+    // Kick 3 candidate origin = (3+0, 18-2) = (3,16):
+    //   cells (4,16),(4,17),(5,17),(4,18) — (4,18) is blocked → collides.
+    // Kick 4 candidate origin = (3-1, 18-2) = (2,16):
+    //   cells (3,16),(3,17),(4,17),(3,18) — all free → accepted!
+    //
+    // So on this board, kick 4 is the first unblocked: origin shifts by (-1,-2).
+    let mut board = Board::empty();
+    board.set(4, 18, PieceKind::T); // block kick-0 cell
+    board.set(4, 19, PieceKind::T); // block kick-0 and kick-1 cell
+    board.set(5, 19, PieceKind::T); // block kick-0 cell
+    board.set(4, 20, PieceKind::T); // block kick-0 and kick-2 cell
+
+    let piece = spawn(PieceKind::T); // origin (3,18), Zero state
+    let rotated = rotate(&piece, RotationDir::Cw, &board).expect("kick 4 (-1,-2) should succeed");
+    assert_eq!(rotated.rotation, Rotation::R);
+    // Kick 4: col -1, row -2
+    assert_eq!(
+        rotated.origin,
+        (piece.origin.0 - 1, piece.origin.1 - 2),
+        "kick 4 should shift origin by (-1,-2)"
+    );
+}
+
+/// When ALL 5 kicks are blocked, rotate returns Err(SrsError::BlockedAfterAllKicks).
+///
+/// Strategy: place the T piece near the left wall in the Zero state,
+/// then surround the entire candidate region so every kick position
+/// is obstructed.
+#[test]
+fn srs_rotation_blocked_returns_err() {
+    // Place T at origin (0, 20) — already close to the left wall.
+    // T in state R at various kick origins will hit the left wall (col<0)
+    // or blocked cells. We also fill a solid wall to block rightward kicks.
+    let mut board = Board::empty();
+
+    // Fill cols 0..=4, rows 19..=23 solid — this blocks the R shape
+    // for all 5 kick candidates of a T near (0,20).
+    for row in 19..=23_usize {
+        for col in 0..=4_usize {
+            board.set(col, row, PieceKind::T);
+        }
+    }
+
+    // Place the actual T piece at (0,20) — Zero state cells are
+    // (0+1,20+0)=(1,20), (0+0,20+1)=(0,21), (0+1,20+1)=(1,21),
+    // (0+2,20+1)=(2,21). Those are blocked in our filled region.
+    // We want to test rotation *of* the piece, not spawn collision,
+    // so we clear just the cells the T-Zero occupies so it "exists":
+    // But Board::set only sets; we can't unset. Instead, let's place
+    // the T piece at a position where it sits legally and all R
+    // destinations are walled off.
+    //
+    // Simpler approach: clear board, place T at col 1, row 1 (hidden buffer),
+    // then fill a box around all 5 candidate R positions.
+    let mut board2 = Board::empty();
+    let origin = (1_i32, 1_i32);
+    // JLSTZ Zero→R kicks: (0,0),(-1,0),(-1,+1),(0,-2),(-1,-2)
+    // For each kick, T in state R cells are (0,0),(0,1),(0,2),(1,1)
+    // relative to candidate origin. Block every cell that could be reached.
+    let t_r_offsets: &[(i32, i32)] = &[(0, 0), (0, 1), (0, 2), (1, 1)];
+    let kicks: &[(i32, i32)] = &[(0, 0), (-1, 0), (-1, 1), (0, -2), (-1, -2)];
+    for &(kc, kr) in kicks {
+        let cand_origin = (origin.0 + kc, origin.1 + kr);
+        for &(dc, dr) in t_r_offsets {
+            let col = cand_origin.0 + dc;
+            let row = cand_origin.1 + dr;
+            if (0..10).contains(&col) && (0..40).contains(&row) {
+                board2.set(col as usize, row as usize, PieceKind::T);
+            }
+        }
+    }
+
+    let piece = blocktxt::game::piece::Piece {
+        kind: PieceKind::T,
+        rotation: Rotation::Zero,
+        origin,
+    };
+    let result = rotate(&piece, RotationDir::Cw, &board2);
+    assert_eq!(
+        result,
+        Err(SrsError::BlockedAfterAllKicks),
+        "all kicks blocked should return Err"
+    );
 }


### PR DESCRIPTION
## Summary

- Extends `src/game/piece.rs` shape tables with rotation states R, Two, L for all 7 piece kinds (derived by rotating Zero-state offsets 90° CW within each piece's bounding box).
- Implements `src/game/srs.rs` with two separate kick tables (`JLSTZ_KICKS`, `I_KICKS`) and `rotate(piece, dir, board) -> Result<Piece, SrsError>` using the canonical SRS algorithm: try 5 kick offsets in order, first non-colliding position wins.
- Un-ignores the Sprint-1 red test `srs_i_rotation_clockwise_applies_kick_offset` and updates its signature to pass `&Board::empty()`.
- Adds 5 new golden-suite tests covering full rotation cycles, kick selection, and blocked-all-kicks error path.

## Test plan

- [x] `srs_i_rotation_clockwise_applies_kick_offset` — Sprint-1 test now green; I Zero→R on open board, (0,0) kick, origin unchanged.
- [x] `srs_jlstz_open_board_zero_to_r_uses_0_0_kick` — all 5 JLSTZ pieces, open board, Zero→R, (0,0) kick.
- [x] `srs_jlstz_cw_full_cycle_returns_to_zero` — all 5 JLSTZ, CW round-trip Zero→R→2→L→Zero, origin unchanged.
- [x] `srs_i_ccw_full_cycle_returns_to_zero` — I piece CCW round-trip, origin unchanged.
- [x] `srs_rotation_uses_first_unblocked_kick` — board blockers force T piece past kicks 0–3 to kick 4 (−1,−2).
- [x] `srs_rotation_blocked_returns_err` — all 5 candidates blocked, returns `Err(BlockedAfterAllKicks)`.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `bash scripts/check-naming.sh` clean.
- [x] All 23 tests pass.

Closes #11