### PR TITLE
feat(dx): add Justfile (#50)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,83 @@
+# blocktxt — terminal falling-block puzzle game
+# https://github.com/NikolayS/blocktxt-1
+#
+# Run `just --list` to see all available recipes.
+
+set shell := ["bash", "-uc"]
+
+export CARGO_TERM_COLOR := "always"
+
+# --- build ---
+
+# Compile a debug build
+build:
+    cargo build
+
+# Compile an optimised release build
+release:
+    cargo build --release
+
+# Install the binary from this worktree
+install:
+    cargo install --locked --path .
+
+# --- run ---
+
+# Run the game (pass extra flags after --: `just run -- --seed 42`)
+run *args:
+    cargo run --release -- {{args}}
+
+# --- test ---
+
+# Run the full test suite
+test:
+    cargo test
+
+# Run only lib unit tests (fast iteration)
+test-quick:
+    cargo test --lib
+
+# --- lint / format ---
+
+# Format all crates in-place
+fmt:
+    cargo fmt --all
+
+# Check formatting without modifying files
+fmt-check:
+    cargo fmt --all -- --check
+
+# Run Clippy with all warnings as errors
+clippy:
+    cargo clippy --all-targets -- -D warnings
+
+# --- security / compliance ---
+
+# Check dependency licences and advisories
+deny:
+    cargo deny check
+
+# Scan source files for the prohibited trademark term
+naming:
+    bash scripts/check-naming.sh
+
+# --- ci ---
+
+# Full local CI gate: fmt-check clippy test deny naming
+ci: fmt-check clippy test deny naming
+
+# --- misc ---
+
+# Print the release binary size; warn if > 8 MiB
+bench-size: release
+    @bin=target/release/blocktxt; \
+    actual=$(wc -c < "${bin}" | tr -d ' '); \
+    mib=$(( actual / 1048576 )); \
+    echo "Binary size: ${actual} bytes (${mib} MiB)"; \
+    if (( actual > 8388608 )); then \
+      echo "WARNING: binary exceeds 8 MiB release guard" >&2; \
+    fi
+
+# Remove build artefacts (including worktree target dirs)
+clean:
+    cargo clean && rm -rf .worktrees/*/target

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Requires Rust stable (MSRV 1.75).
 cargo install --locked --git https://github.com/NikolayS/blocktxt-1
 ```
 
+## Development
+
+This repo ships a `Justfile`. Install [just](https://github.com/casey/just)
+(`brew install just`) and run `just --list` to see common tasks.
+Shortcuts: `just run`, `just ci`, `just release`.
+
 ## Play
 
 Run `blocktxt`. Keybinds:


### PR DESCRIPTION
## Summary

- Adds `Justfile` with 14 recipes covering the full local dev workflow.
- Exports `CARGO_TERM_COLOR=always` so colours survive CI pipes.
- `just ci` chains `fmt-check clippy test deny naming`, mirroring GitHub
  Actions.
- `just bench-size` warns when the release binary exceeds the 8 MiB release
  guard (matches `release.yml`).
- Adds a short **Development** section to `README.md` pointing at
  `just --list`.

## Test plan

- [ ] `just --list` shows all 14 recipes with doc comments
- [ ] `just build` — debug build succeeds
- [ ] `just fmt-check` — passes (no formatting issues)
- [ ] `just clippy` — passes with `-D warnings`
- [ ] `just test` — all tests pass
- [ ] `just naming` — no prohibited trademark term found
- [ ] `just ci` — all five steps green locally

## Addresses #50 (Track D)

🤖 Generated with [Claude Code](https://claude.com/claude-code)