### PR TITLE
spec: blocktxt multiplayer v0.2 (samospec draft)

### DIFF
--- a/.samo/config.json
+++ b/.samo/config.json
@@ -53,5 +53,17 @@
   },
   "publish_lint": {
     "allowed_commands": []
+  },
+  "calibration": {
+    "sample_count": 1,
+    "tokens_per_round": [
+      0
+    ],
+    "rounds_to_converge": [
+      0
+    ],
+    "cost_per_run_usd": [
+      0
+    ]
   }
 }

--- a/.samo/spec/multiplayer-v1/SPEC.md
+++ b/.samo/spec/multiplayer-v1/SPEC.md
@@ -1,4 +1,4 @@
-# blocktxt multiplayer — SPEC v0.1
+# blocktxt multiplayer — SPEC v0.2
 
 > **Scope note.** This document specifies the two-player competitive
 > multiplayer mode added to blocktxt in game version **v0.2**. The project
@@ -21,18 +21,28 @@ engineering — deterministic simulation, network protocols, matchmaking
 — that the repo has deliberately avoided so far, so v0.2 is the right
 moment to pay that cost once, cleanly, rather than bolting it on later.
 
+**v0.2 public rollout is scoped to a single-region beta.** We ship a
+single production server node behind a single DNS name; horizontal scale
+and multi-region are deferred to v0.3 (see §4.6).
+
 **Non-goals for this version (enforced strictly).**
 
 - **NOT a spectator / streaming feature.** No watch-only clients in v1.
 - **NOT a leaderboard / rating service.** Matches are ad-hoc; no Elo,
   no persistent win/loss records beyond a local session counter.
 - **NOT a lobby / chat / social product.** Two players connect via a
-  short room code. No friends list, no chat UI, no profiles.
+  short room code plus a host admission step. No friends list, no chat
+  UI, no profiles.
 - **NOT cross-version compatible.** v0.2 clients only talk to v0.2
   servers and v0.2 peers. Version mismatch → clean refusal.
 - **NOT a replacement for single-player.** Single-player v0.1 remains
   the default launch mode; multiplayer is opt-in via a subcommand.
 - **NOT >2 players.** No free-for-all, no teams. Exactly 2.
+- **NOT a public offline-multiplayer feature.** `mp local` is deferred
+  out of the v0.2 public surface (see §5.6); the same two-player engine
+  is exercised only as an internal test harness.
+- **NOT a horizontally scaled deployment in v1.** Exactly one server
+  instance in production; registry/sticky-routing design deferred.
 
 ## 2. Design decisions (resolved from interview)
 
@@ -64,9 +74,12 @@ over:
 - **Rollback netcode**: premium experience but a full sprint of work
   we can defer until there's demand.
 
-Server is stateless between matches and horizontally scalable; a single
-$5/month VM comfortably hosts hundreds of concurrent matches at 60 Hz
-with the tick budget below.
+For v0.2 the server is **deployed as a single node** behind a single
+DNS name. Match state (boards, RNG, input queues) lives in-process;
+room-code matchmaking is an in-memory registry on that node. The
+server is stateless *across restarts* (we do not persist matches) but
+it is emphatically **not** horizontally shardable yet — see §4.6 for
+what changes in v0.3.
 
 ### 2.3 Sync model — server-authoritative fixed-tick, client input-forward with input delay
 
@@ -77,13 +90,24 @@ with the tick budget below.
 - Server applies inputs at **`client_tick + INPUT_DELAY`** where
   `INPUT_DELAY = 2 ticks ≈ 33 ms`. This absorbs typical jitter without
   visible lag and avoids the complexity of rollback.
-- Server broadcasts a **state snapshot** every tick (two boards,
-  scores, incoming-garbage queues, active pieces, phase). Snapshots
-  are delta-compressed against the last-acked snapshot per client.
-- No client-side prediction in v1: on LAN / sub-50 ms RTT the
-  round-trip + 2-tick input delay is imperceptible for falling-block-
-  game-paced play. Prediction is an explicit v2 lever if telemetry shows we need
-  it.
+- Server emits a **state snapshot** every tick (two boards, scores,
+  incoming-garbage queues, active pieces, phase). Snapshots are
+  delta-encoded against the most recent snapshot the client has
+  acked; see §4.4 for the bounded ack window, keyframe policy, and
+  backpressure rules.
+- **Local rendering policy.** The player's *own* active piece is drawn
+  from a local input-echo ghost (the client applies its own input
+  optimistically to the mirrored snapshot for that piece only) so that
+  horizontal moves and soft-drops feel immediate. The well, the
+  opponent's board, score, incoming-garbage queue, and all lock events
+  are drawn strictly from the server snapshot. If the server
+  snapshot's piece state diverges from the local ghost (e.g. server
+  rejected an input), the client snaps to the server state on the next
+  frame — no interpolation, no rollback.
+- No speculative execution past the active piece: lock, clear, and
+  garbage are server-authoritative and rendered only when snapshotted.
+  Prediction of lock/clear is an explicit v2 lever if telemetry shows
+  we need it.
 
 ### 2.4 Transport — TLS-terminated WebSocket, binary frames
 
@@ -98,30 +122,40 @@ with the tick budget below.
 
 ### 2.5 Scale target — 2 players, 60 Hz, 150 ms RTT budget
 
-| Dimension          | v0.1 target                                        |
-|--------------------|----------------------------------------------------|
-| Players per match  | exactly 2                                          |
-| Server tick rate   | 60 Hz                                              |
-| Client frame rate  | 60 fps (unchanged)                                 |
-| RTT budget         | ≤ 150 ms one-way latency for "feels responsive"    |
-| Bandwidth / client | ≤ 8 KiB/s steady state (delta snapshots)           |
-| Concurrent matches | 200 per 1-vCPU / 512 MiB server                    |
-| Match duration cap | 10 minutes (hard cap; otherwise sudden-death)      |
+| Dimension                    | v0.2 target                                                 |
+|------------------------------|-------------------------------------------------------------|
+| Players per match            | exactly 2                                                   |
+| Server tick rate             | 60 Hz                                                       |
+| Client frame rate            | 60 fps (unchanged)                                          |
+| RTT budget                   | ≤ 150 ms round-trip (≈ 75 ms one-way) for "feels responsive"|
+| Bandwidth / client           | ≤ 8 KiB/s steady state (delta snapshots); hard cap 32 KiB/s |
+| Target concurrent matches    | 200 per 1-vCPU / 512 MiB server (load-tested in §6.2)       |
+| Admission-control hard cap   | 256 matches / node; new rooms rejected with `ServerFull`    |
+| Match duration cap           | 10 minutes (hard cap; resolves via sudden-death, §5.3.2)    |
+
+The 150 ms budget is **round-trip**; it is the figure §2.3 uses when
+it calls RTT + 2-tick input delay imperceptible. Any reviewer-facing
+claim elsewhere in this doc that uses "latency" refers to one-way
+latency (≈ RTT/2).
 
 ## 3. User stories
 
 1. **Casey the commuter** (persona: single-player regular, 30 min/day
    on trains). *Action:* runs `blocktxt mp host`, reads aloud the
-   5-character room code to a friend on a call. *Outcome:* within 10
-   seconds both are playing head-to-head; no signup, no account, no
-   browser.
+   5-character room code to a friend on a call, then presses `y` when
+   the HUD shows `join request from 203.0.113.4 — accept? [y/N]`.
+   *Outcome:* within 15 seconds both are playing head-to-head; no
+   signup, no account, no browser, and a stranger who guesses the code
+   is refused because the host never approved them.
 
 2. **Riley the reviewer** (persona: rust-curious developer trying
    blocktxt for the first time). *Action:* runs `blocktxt mp join
    ABCDE` from a fresh install behind a corporate HTTP proxy.
    *Outcome:* connection succeeds over port 443; if it fails, the CLI
    prints an actionable error naming *which* step failed (DNS, TLS,
-   handshake, version-mismatch, room-not-found).
+   handshake, version-mismatch, room-not-found, host-declined,
+   rate-limited, server-full), with all server-provided error text
+   sanitized of control characters (§4.5).
 
 3. **Sam the skeptic** (persona: privacy-conscious, offline-first).
    *Action:* launches `blocktxt` with no arguments. *Outcome:* gets
@@ -134,14 +168,15 @@ with the tick budget below.
    (4-line) while their opponent has a full well. *Outcome:* opponent
    receives 4 garbage rows within one server tick of the flash-phase
    completing, and the garbage-incoming indicator in Taylor's HUD
-   shows pending rows they're about to send.
+   shows pending rows they're about to send, with colour ramp steps
+   defined at deterministic thresholds (§5.3.3).
 
 5. **Jordan the judge** (persona: QA / release-blocking role).
    *Action:* runs the manual multiplayer test plan against a release
-   candidate on macOS arm64 and Linux x86_64 simultaneously.
-   *Outcome:* can verify in under 15 minutes that matchmaking,
-   gameplay, disconnection, and clean shutdown all behave; any failure
-   maps to a specific checklist item.
+   candidate on macOS arm64, macOS x86_64, and Linux x86_64
+   simultaneously. *Outcome:* can verify in under 20 minutes that
+   matchmaking, gameplay, disconnection, sudden-death, and clean
+   shutdown all behave; any failure maps to a specific checklist item.
 
 ## 4. Architecture
 
@@ -166,18 +201,22 @@ with the tick budget below.
 │                          net thread (tokio)     render/input (main)   │
 │                                 │                       │             │
 │                                 └── shared state ◀──────┘             │
-│                                     (sim::SnapshotMirror)             │
+│                                     (sim::SnapshotMirror + echo ghost)│
 └─────────────────────────────────┬─────────────────────────────────────┘
                                   │ wss://  (TLS 1.3, binary frames)
                                   ▼
 ┌──────────────────── blocktxt-server (new binary) ─────────────────────┐
 │                                                                       │
-│  ws accept ─▶ session ─▶ matchmaker (room code)                       │
-│                    │         │                                        │
-│                    └────────▶│  match ─▶ sim (60 Hz, authoritative)   │
-│                              │             │                          │
-│                              │             └─▶ snapshot diff          │
-│                              └───────────────▶ broadcast to 2 peers   │
+│  ws accept ─▶ session ─▶ admission ─▶ matchmaker (room registry)      │
+│  (TLS, limits)             (caps)       │                             │
+│                                          │                            │
+│                                          ▼                            │
+│                                      match ─▶ sim (60 Hz, auth.)      │
+│                                         │       │                     │
+│                                         │       └─▶ snapshot diff     │
+│                                         └─────────▶ broadcast (2)     │
+│                                                                       │
+│  metrics (127.0.0.1:9090, auth)     access log (match_id + keyed-hash)│
 └───────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -187,28 +226,41 @@ New crates / modules in the workspace:
   deterministic simulation. No `Instant::now()`, no thread-local RNG,
   no I/O. Shared verbatim between client and server.
 - `blocktxt-proto` (library): wire-format types, framing, version
-  constants, `Encode`/`Decode` traits.
-- `blocktxt` (existing binary): gains `mp host` / `mp join` /
-  `mp local` subcommands.
-- `blocktxt-server` (new binary): WebSocket listener, matchmaker,
-  match runner.
+  constants, `Encode`/`Decode` traits, explicit size caps.
+- `blocktxt` (existing binary): gains `mp host` / `mp join`
+  subcommands. `mp local` is present but gated behind the
+  `--internal-harness` feature flag and not documented in the public
+  CLI help (see §5.6).
+- `blocktxt-server` (new binary): WebSocket listener, admission
+  controller, matchmaker, match runner.
 
 ### 4.2 Key abstractions
 
 - **`sim::Match`** — holds two `GameState` instances plus a shared
-  garbage exchange queue. Pure function: `step(inputs_a, inputs_b,
-  dt) -> (events_a, events_b, garbage_delta)`.
-- **`sim::DetRng`** — seeded ChaCha20 RNG, replaces `StdRng` in the
-  simulation crate. Both 7-bag generators are seeded from the match
-  seed so sequences are reproducible for replays / desync audits.
+  garbage exchange queue. Pure function:
+  `step(inputs_a, inputs_b) -> (events_a, events_b, garbage_delta)`.
+  There is no `dt` parameter; one call advances exactly one tick. The
+  client mirror calls `step` zero or one times per rendered frame; it
+  never calls it with any other cadence.
+- **`sim::DetRng`** — seeded ChaCha20 RNG used for piece generation
+  (7-bag). Both players' bags are derived from the match seed via the
+  pinned derivation in §5.3.1 so sequences are reproducible for
+  replays / desync audits.
 - **`proto::Frame`** — tagged union of `Hello`, `HostRoom`,
-  `JoinRoom`, `RoomReady`, `MatchStart`, `Input`, `Snapshot`, `Ack`,
+  `JoinRoom`, `JoinRequest`, `HostDecision`, `RoomReady`,
+  `MatchStart`, `Input`, `Snapshot`, `Keyframe`, `Ack`, `Ping`,
   `Pong`, `Goodbye`, `Error`. Versioned by the `Hello` handshake.
 - **`client::SnapshotMirror`** — lock-free SPSC slot that the net
-  thread writes and the render thread reads each frame. One tick
-  behind at worst.
+  thread writes and the render thread reads each frame. Holds the
+  latest fully-applied snapshot plus the running keyframe baseline.
+- **`client::EchoGhost`** — render-thread-only shadow of the local
+  active piece's `(x, y, rot)`, updated from keyboard input and reset
+  from the snapshot every time the server advances the piece
+  (lock/spawn/rotate-reject). Never writes into the simulation.
 - **`server::RoomCode`** — 5-character `Crockford-base32` code (no
   `ILOU`); 32⁵ ≈ 33 M codes. Matchmaker rejects codes already live.
+- **`server::Admission`** — per-IP and global token buckets plus
+  concurrency counters; see §4.4.
 
 ### 4.3 Wire protocol (v1)
 
@@ -217,23 +269,128 @@ WebSocket binary messages. Fields are little-endian `bincode` v2 with
 the `varint` codec. `proto_version = 1` is carried in `Hello` and any
 mismatch is fatal.
 
-| Tag | Name          | Fields (summary)                                  |
-|----:|---------------|---------------------------------------------------|
-| 0x01| Hello         | proto_version, client_build, capabilities         |
-| 0x02| HostRoom      | — (server assigns code)                           |
-| 0x03| JoinRoom      | code (5 bytes)                                    |
-| 0x04| RoomReady     | code, role (host/guest), peer_build               |
-| 0x05| MatchStart    | match_id, seed (u64), start_tick                  |
-| 0x06| Input         | client_tick, seq, bitset of Inputs                |
-| 0x07| Snapshot      | server_tick, ack_seq, delta-encoded state         |
-| 0x08| Ack           | ack_tick                                          |
-| 0x09| Pong          | echoed nonce, server_tick                         |
-| 0x0A| Goodbye       | reason (enum)                                     |
-| 0x0B| Error         | code, human-readable string                       |
+| Tag  | Name          | Fields (summary)                                  |
+|-----:|---------------|---------------------------------------------------|
+| 0x01 | Hello         | proto_version (u16), client_build (str ≤ 64)      |
+| 0x02 | HostRoom      | — (server assigns code)                           |
+| 0x03 | JoinRoom      | code ([u8; 5])                                    |
+| 0x04 | JoinRequest   | code, peer_build (str ≤ 64), peer_ip_hash ([u8;8])|
+| 0x05 | HostDecision  | accept (bool), reason (enum)                      |
+| 0x06 | RoomReady     | code, role (host/guest), peer_build               |
+| 0x07 | MatchStart    | match_id (u128), seed (u64), start_tick (u32)     |
+| 0x08 | Input         | client_tick (u32), seq (u32), inputs (u16 bitset) |
+| 0x09 | Snapshot      | server_tick, ack_seq, baseline_tick, delta bytes  |
+| 0x0A | Keyframe      | server_tick, full state blob                      |
+| 0x0B | Ack           | ack_tick (u32)                                    |
+| 0x0C | Ping          | nonce (u64), client_send_tick (u32)               |
+| 0x0D | Pong          | nonce (u64), server_tick (u32)                    |
+| 0x0E | Goodbye       | reason (enum)                                     |
+| 0x0F | Error         | code (enum), detail (ASCII-only str ≤ 256)        |
 
-`Input` frames are idempotent and replay-safe (seq numbers). Snapshots
-are sent unconditionally every tick at 60 Hz; the server rate-limits
-them to a minimum tick gap of 1 even when acks stall.
+**`capabilities` is intentionally not present in v1.** Forward
+compatibility is handled by strict `proto_version` mismatch refusal
+per §1; any future optional behaviour will be gated on a bumped
+version, not on in-band negotiation. This keeps v1 parsing paths
+shorter and removes a class of downgrade attacks.
+
+**`Input` bit layout (u16):**
+
+| Bit | Name          | Bit | Name            |
+|----:|---------------|----:|-----------------|
+|  0  | MoveLeft      |  6  | RotateCCW       |
+|  1  | MoveRight     |  7  | RotateCW        |
+|  2  | SoftDrop      |  8  | Rotate180       |
+|  3  | HardDrop      |  9  | Hold            |
+|  4  | DAS-charge    | 10  | Pause-request   |
+|  5  | (reserved=0)  | 11–15 | (reserved=0)  |
+
+Reserved bits MUST be zero on the wire; the server closes the
+connection with `Error(MalformedInput)` on any reserved bit set.
+
+**Ping/Pong.** Clients emit `Ping(nonce)` every 500 ms; the server
+replies `Pong(nonce, server_tick)`. This matches RFC 6455 directional
+semantics. The WebSocket-level control frames are not used for game
+timing; we carry our own so the server `tick` is directly observable.
+
+### 4.4 Reliability, backpressure & admission (new in v0.2)
+
+The following limits are authoritative and enforced in code, not just
+documentation.
+
+**Frame & connection limits**
+
+| Limit                                   | Value                       |
+|-----------------------------------------|-----------------------------|
+| Max WebSocket message size              | 16 KiB                      |
+| Max decoded allocation per frame        | 64 KiB (hard, pre-alloc)    |
+| Server outbound queue depth per client  | 8 frames; overflow → close  |
+| Server inbound frame rate per client    | 240 frames/s sustained      |
+| Invalid-frame budget per client         | 4 per 10 s → close          |
+| Malformed-frame ban (per IP)            | 10 invalid closes / 5 min   |
+| Idle pre-match room lifetime            | 60 s → room destroyed       |
+| Match lifetime                          | 10 min → sudden-death (§5.3.2)|
+
+**Matchmaking & session limits**
+
+| Limit                                   | Value                       |
+|-----------------------------------------|-----------------------------|
+| `HostRoom` per IP                       | 3 per minute                |
+| `JoinRoom` per IP                       | 10 per minute               |
+| Concurrent WS sessions per IP           | 8                           |
+| Concurrent rooms per IP (as host)       | 2                           |
+| Total rooms per node (admission cap)    | 256 → `Error(ServerFull)`   |
+| Total sessions per node (admission cap) | 1024 → TLS accept refused   |
+
+All buckets are token buckets with per-minute refill; admission checks
+run before room registry mutation.
+
+**Snapshot/ack window.**
+
+- The server maintains a ring buffer of the last **32 snapshots**
+  (533 ms at 60 Hz) per client as delta baselines.
+- Clients send `Ack(ack_tick)` on every snapshot received; the server
+  advances the baseline to the oldest unacked snapshot.
+- If the unacked window reaches 32, the server sends a full
+  `Keyframe` and resets the baseline to it.
+- If the unacked window exceeds 60 snapshots (1 s), the server closes
+  the session with `Goodbye(ClientStalled)`; the peer receives
+  `Goodbye(PeerDisconnected)` and wins by default.
+- Snapshots are emitted at most **once per tick**; under outbound
+  backpressure the server coalesces pending snapshots into the next
+  `Keyframe` rather than queueing unbounded.
+
+**Host admission.** A `JoinRoom` does not connect the two clients
+directly. The server routes a `JoinRequest` to the host with a
+truncated, keyed hash of the joiner's IP (§5.5.3). The host replies
+`HostDecision(accept=true|false)` within 15 s or the join is
+auto-rejected. Only on `accept=true` does the match start. This
+removes the "guessable 5-character code is the only credential" class
+of hijack.
+
+### 4.5 Terminal-safe error rendering
+
+Any server-provided string surfaced to the user terminal (`Error.detail`,
+`Goodbye.reason` human text, room codes) is sanitized by the client:
+
+- Strip everything outside printable ASCII `0x20–0x7E` plus `\n`.
+- Cap at 200 display columns.
+- Render through the existing TUI overlay, never via raw `print!`.
+
+The protocol `Error.detail` field is declared ASCII-only on the wire
+(validated server-side on emit and client-side on decode); a
+self-hosted malicious server cannot inject ANSI escapes because the
+client drops them before paint.
+
+### 4.6 Deployment model (v0.2 beta)
+
+- One production node behind one DNS name; no load balancer, no
+  sticky routing. Room registry is an in-process `DashMap`.
+- If the node restarts, in-flight matches are abandoned with
+  `Goodbye(ServerRestart)`; clients show a retriable error.
+- Horizontal scale and a shared room-routing tier (likely
+  Redis-backed matchmaker + sticky WS routing by room code) are
+  explicitly a **v0.3** workstream and are out of scope here. The
+  protocol does not yet encode cross-node room handoff.
 
 ## 5. Implementation details
 
@@ -241,14 +398,16 @@ them to a minimum tick gap of 1 even when acks stall.
 
 - Extract `src/game/` into `blocktxt-sim`. Swap `StdRng` for
   `ChaCha20Rng` seeded from the match seed.
-- Remove all `Instant::now()` from the simulation; time advances only
-  via `step(dt)` where `dt` is always exactly one tick on the server.
+- Remove all `Instant::now()` from the simulation; time advances
+  strictly via tick-accurate `step()` calls with no `dt` parameter.
 - Add a property test: given the same seed and the same input stream,
   two independent runs produce byte-identical `Match` state after N
   ticks (N = 10 000).
 - The *client* continues to use a real clock for animations (juice,
   spawn-fade, score rollup) — those are rendered from the mirrored
   snapshot and never feed back into simulation.
+- Cross-platform digest check runs on macOS arm64, macOS x86_64, and
+  Linux x86_64 in CI (§6.3).
 
 ### 5.2 State transitions (client)
 
@@ -259,9 +418,14 @@ them to a minimum tick gap of 1 even when acks stall.
                   │ any key (single-player)             │
                   ▼                                     ▼
             ┌────────────┐                      ┌────────────────┐
-            │  Playing   │                      │ WaitingForPeer │
+            │  Playing   │                      │ WaitingForPeer │ (host: show code)
             │ (local v1) │                      └───────┬────────┘
-            └────────────┘                              │ RoomReady
+            └────────────┘                              │ JoinRequest (host only)
+                                                        ▼
+                                                ┌────────────────┐
+                                                │  AwaitingAdmit │ (y/n prompt)
+                                                └───────┬────────┘
+                                                        │ HostDecision accept
                                                         ▼
                                                 ┌────────────────┐
                                                 │  MatchStarting │ (3-2-1 countdown)
@@ -279,52 +443,153 @@ them to a minimum tick gap of 1 even when acks stall.
 
 ### 5.3 Garbage exchange
 
-- Line clears produce `garbage_out = lines_cleared - 1` (standard
-  standard versus-mode rule; single clears send 0). B2B quads send 5.
-- Garbage is queued per-recipient on the server. Before the
-  recipient's next piece spawn, the server drains the queue by
-  inserting up to 8 rows of garbage at the bottom of their board,
-  with one random gap column per row (RNG seeded from match seed +
-  tick + recipient id, so deterministic).
-- Incoming-garbage indicator: a HUD column on the inboard side of the
-  playfield shows pending rows; same colour ramp as existing animation
-  DIM → OVERLAY → NEW_BEST as the queue grows.
+#### 5.3.1 Send table (authoritative)
+
+| Clear type                           | Garbage rows sent |
+|--------------------------------------|------------------:|
+| Single (1 line)                      | 0                 |
+| Double (2 lines)                     | 1                 |
+| Triple (3 lines)                     | 2                 |
+| Quad (4 lines)                       | 4                 |
+| T-spin single                        | 2                 |
+| T-spin double                        | 4                 |
+| T-spin triple                        | 6                 |
+| B2B bonus (consecutive quad/T-spin)  | +1 flat           |
+| Combo (N consecutive clears ≥ 2)     | floor((N-1)/2)    |
+| Perfect clear                        | +10 flat          |
+
+- Arithmetic is on integers; no floating point. All additions are
+  computed in u8 then saturated at 20.
+- The B2B bonus is **+1 flat**, replacing the v0.1-draft "×1.5"
+  language; rounding mode is therefore not needed and no test should
+  assume one.
+- Drain cap: up to **8 rows** inserted per piece-spawn. Any excess
+  **stays queued** and drains on the following spawns; the queue is
+  bounded at 40 rows (double-well) above which further incoming
+  garbage is dropped and the sender's HUD flashes `capped`.
+
+#### 5.3.2 Sudden-death (10-minute cap)
+
+At `tick == 36000` (10 min × 60 Hz) both wells enter sudden-death:
+
+- Garbage drain cap per spawn rises from 8 to 20.
+- An extra garbage row is inserted into each well every 2 s,
+  deterministically (same RNG derivation as §5.3.3), bottom-up, with
+  one random gap column.
+- First top-out wins as usual. If both top-out on the same tick, the
+  winner is the player with the lower aggregate well height at the
+  start of that tick; further ties are resolved by match_id parity
+  (`host wins if match_id is even`). This last tiebreak is arbitrary
+  on purpose — it must be deterministic and it is not worth further
+  design.
+
+#### 5.3.3 Garbage RNG derivation (pinned)
+
+Garbage gap columns are drawn from an RNG independent of the 7-bag
+stream:
+
+```
+garbage_rng(recipient, tick) =
+    ChaCha20Rng::from_seed(
+        blake3(match_seed_le_bytes ∥ [recipient_id] ∥ tick_le_bytes)
+            .as_bytes()[..32]
+    )
+```
+
+Called once per inserted row; the first `u8 % WELL_WIDTH` output is
+the gap column. This derivation is part of the wire contract: any
+conforming implementation must reproduce the same gap sequence from
+the same `(match_seed, recipient_id, tick)` triple.
+
+#### 5.3.4 HUD indicator thresholds
+
+Pending-row indicator colour ramp (uses existing animation palette):
+
+| Pending rows | Colour step      |
+|-------------:|------------------|
+| 0            | hidden           |
+| 1–3          | `DIM`            |
+| 4–7          | `OVERLAY`        |
+| 8+           | `NEW_BEST` (red) |
+| queue capped | flashing `NEW_BEST` at 4 Hz |
 
 ### 5.4 Disconnect & lag handling
 
-- Heartbeat: client sends `Pong(nonce)` every 500 ms; server replies.
-  No pong for 3 s → server declares the session stalled and awards
-  the match to the peer.
+- Heartbeat: client sends `Ping(nonce)` every 500 ms; server replies
+  `Pong(nonce, server_tick)`. No pong for 3 s → client declares
+  connection stalled and emits `Goodbye(ClientStalled)` before
+  closing. Symmetrically, no ping for 3 s → server awards the match
+  to the peer.
 - If the *peer* disconnects mid-match, the surviving client gets a
   `Goodbye(PeerDisconnected)` and a win by default.
 - Clean shutdown: Ctrl-C / SIGTERM sends `Goodbye(UserQuit)` before
-  closing the socket.
+  closing the socket. The shutdown path is exercised by an automated
+  test (§6.2).
 
 ### 5.5 Security posture
 
+#### 5.5.1 Transport and parsing
+
 - TLS 1.3 only; `rustls` with the `ring` provider. No plaintext
   fallback.
-- Room codes rate-limited: ≤ 10 `JoinRoom` attempts per IP per minute.
+- All frame-size, allocation, queue-depth, and frame-rate limits in
+  §4.4 are enforced before the frame is decoded.
 - Server ignores client-supplied `server_tick` fields; tick is a
   server-owned monotonic counter.
 - Server validates every client `Input` against the simulation — an
   input that names a non-existent move (e.g. `HardDrop` during
-  `Phase::GameOver`) is silently dropped, not crash-inducing.
-- No persistent data about players is stored server-side. Logs are
-  match_id + truncated IP hash, 7-day retention.
+  `Phase::GameOver`) is silently dropped; any reserved bit set
+  increments the invalid-frame budget.
+- Client sanitizes all server-origin strings before painting (§4.5).
+
+#### 5.5.2 Matchmaking abuse controls
+
+All limits in §4.4 are enforced. `HostRoom`, `JoinRoom`, concurrent
+sessions, concurrent rooms, and per-node caps are each tracked with
+a token bucket or counter. On breach, the offending frame receives
+`Error(RateLimited|ServerFull|TooManySessions)` and the session is
+closed.
+
+#### 5.5.3 Logging & IP handling
+
+- No persistent data about players is stored server-side beyond logs.
+- Access log fields: `match_id`, `event`, `ip_hash`, `ts`.
+- `ip_hash = blake3(salt ∥ client_ip)[..8]` where `salt` is a
+  server-held 256-bit secret rotated every 24 h. Previous 7 salts are
+  retained in memory so abuse correlation works across rotation
+  boundaries. Salts are never written to disk; a restart rotates the
+  salt.
+- Log retention: 7 days, then deleted. Only `ip_hash` and `match_id`
+  are present in retained logs; raw IPs exist only in ephemeral
+  admission counters and are purged on session close.
+
+#### 5.5.4 Metrics endpoint
+
+A Prometheus `/metrics` endpoint exposes `concurrent_matches`,
+`concurrent_sessions`, `tick_budget_p99`, `admission_rejects_total`,
+and `invalid_frames_total`. It is **bound to `127.0.0.1:9090` only**
+and is scraped by a local node-exporter sidecar; it is never exposed
+on the public TLS listener. Self-hosters wanting remote metrics must
+deploy their own reverse proxy with their own auth.
 
 ### 5.6 CLI surface
 
 ```
 blocktxt                         # unchanged: single-player v0.1
-blocktxt mp host [--server URL]  # host a room, print room code, wait
+blocktxt mp host [--server URL]  # host a room, print room code,
+                                 #  prompt to accept each join request
 blocktxt mp join CODE [--server URL]
-blocktxt mp local                # two local players, split-screen TTY
-                                 #  (no network; dev aid and offline mode)
 ```
 
 `--server` defaults to the compiled-in official URL; overridable for
-self-hosting. `BLOCKTXT_SERVER` env var is also honoured.
+self-hosting. `BLOCKTXT_SERVER` env var is also honoured. **When both
+are set, `--server` wins**; this matches common CLI convention.
+
+`mp local` is **not** a v0.2 public subcommand. The two-player
+single-process harness still exists behind the `internal-harness`
+cargo feature (off by default in release builds) so CI can exercise
+`sim::Match` end-to-end without a network, but it is neither
+advertised in `--help` nor shipped in the release binary.
 
 ## 6. Tests plan
 
@@ -337,13 +602,38 @@ lands, per strict TDD:
   sequences across two independent instances → identical state.
 - **`proto` round-trip** — for every frame variant, `decode(encode(x))
   == x`; malformed bytes → specific `Error` variant (never panic).
+- **`proto` size caps** — frames larger than 16 KiB are rejected
+  without allocation; decoded frames never allocate > 64 KiB.
 - **Version-mismatch refusal** — client with `proto_version = 2`
   against server v1 receives `Error(VersionMismatch)` and exits with
   status 3.
-- **Garbage exchange table** — `lines_cleared → garbage_out` matches
-  the specified table exactly, including B2B × 1.5 rounding.
+- **Garbage exchange table** — every row of §5.3.1 (single through
+  perfect-clear, B2B +1, combo formula) produces the stated row count;
+  queue cap at 40 drops excess; drain cap of 8 (normal) / 20
+  (sudden-death) leaves the correct residue.
+- **Sudden-death trigger** — at tick 36000 exactly, drip garbage
+  engages; tiebreaks (height, match_id parity) resolve as specified.
+- **Garbage RNG derivation** — given a fixed `match_seed`,
+  `recipient_id`, and tick range, gap columns match a checked-in
+  golden vector across macOS arm64 / macOS x86_64 / Linux x86_64.
+- **Input bit layout** — every named bit encodes/decodes; reserved
+  bits set → `Error(MalformedInput)` without panic.
 - **Room-code charset** — generated codes never contain `I`, `L`,
   `O`, `U`; property test over 100 k samples.
+- **Input-delay pipeline** — an input posted at client_tick T is
+  applied at server_tick T+2 under nominal RTT; early inputs queue,
+  late inputs are dropped and logged as `InputTooLate`.
+- **Snapshot delta/keyframe round-trip** — apply a random walk of
+  snapshots; baselines + deltas reconstruct the same `Match` state as
+  re-decoding the keyframes directly.
+- **Ack-window boundary** — with acks stalled for 32 snapshots a
+  keyframe is emitted; at 60 snapshots the session closes with
+  `Goodbye(ClientStalled)`.
+- **Heartbeat stall auto-award** — simulate 3 s of silence; the live
+  peer receives `Goodbye(PeerDisconnected)` within 3.2 s.
+- **Terminal sanitization** — fuzz server-origin strings containing
+  ANSI / CSI / BEL / NUL bytes; the rendered output is pure printable
+  ASCII.
 - **Tick-budget invariant** — server `step` for 2 active matches
   completes in < 1 ms on the reference CI VM (criterion bench gated
   as a test).
@@ -351,65 +641,95 @@ lands, per strict TDD:
 ### 6.2 Integration (green-path, written after the TDD pieces above)
 
 - **Loopback match**: spin up `blocktxt-server` on `127.0.0.1:0`,
-  connect two in-process clients, script a 30-second match, assert a
-  `MatchResult` event is emitted and both clients exit cleanly.
+  connect two in-process clients via `internal-harness`, script a
+  30-second match, assert a `MatchResult` event is emitted and both
+  clients exit cleanly.
+- **Host admission**: scripted guest is refused when host replies
+  `HostDecision(accept=false)`; guest sees `Error(HostDeclined)`.
 - **Disconnect mid-match**: kill one client's socket; assert the
   other receives `Goodbye(PeerDisconnected)` within 3 s.
+- **SIGTERM graceful shutdown**: spawn the host binary, send SIGTERM,
+  assert `Goodbye(UserQuit)` is received by the peer and the process
+  exits 0 within 2 s.
 - **Corporate-proxy simulation**: run the loopback suite through
   `mitmproxy` in forward mode to confirm wss:443 still works.
 - **TLS refusal**: plaintext `ws://` connection attempt → server
   drops with clear error, no process crash.
+- **Rate-limit enforcement**: drive 11 `JoinRoom` from one IP in
+  60 s; 11th returns `Error(RateLimited)`. Drive 4 `HostRoom` per
+  minute; 4th returns `Error(RateLimited)`.
+- **Admission cap**: spin up 256 matches, attempt a 257th, receive
+  `Error(ServerFull)`; existing matches unaffected.
+- **Frame-size enforcement**: send a 17 KiB binary frame; server
+  closes session with `Error(FrameTooLarge)` and increments the
+  invalid-frame budget.
+- **Bandwidth budget**: 60-second loopback match, measure aggregate
+  client→server and server→client bytes; both ends must be
+  ≤ 8 KiB/s mean and ≤ 32 KiB/s peak.
+- **Load test (200 matches)**: gated nightly CI job — 200 concurrent
+  scripted matches against one server node; assert `tick_budget_p99
+  < 4 ms`, `admission_rejects_total == 0`, zero `Goodbye(ClientStalled)`.
 - **Cross-arch determinism**: run the determinism property test on
-  macOS arm64 and Linux x86_64 in CI; seeds must produce identical
-  SHA-256 digests of the final state.
+  macOS arm64, macOS x86_64, and Linux x86_64 in CI; seeds must
+  produce identical SHA-256 digests of the final state.
 
 ### 6.3 CI additions
 
 - New matrix entry: `cargo test -p blocktxt-sim -p blocktxt-proto
-  -p blocktxt-server`.
+  -p blocktxt-server`, run on macOS arm64, macOS x86_64, and
+  Linux x86_64.
 - Fuzz target (`cargo-fuzz`) on `proto::decode` — 5-minute nightly
   run; any panic fails the job.
 - `cargo deny check` gains an advisories gate for `rustls`, `tokio`,
-  `tokio-tungstenite`.
+  `tokio-tungstenite`, `blake3`.
+- Nightly load-test job (§6.2) runs on a dedicated 1-vCPU / 512 MiB
+  runner to validate the headline scale numbers.
 
 ### 6.4 Manual test plan (release-blocking)
 
 Extends `docs/manual-test-plan.md` with a **Multiplayer** section:
 
 - [ ] `mp host` prints a 5-char code; `mp join <code>` on a second
-      machine connects within 2 s.
+      machine shows the host a `y/N` prompt within 2 s.
+- [ ] Host declines → guest sees `host declined` and exits cleanly.
 - [ ] Line clear on host inserts garbage on guest well within one
       visible frame of flash-phase completion.
+- [ ] Quad sends 4 rows; B2B quad sends 5 rows (4 + 1).
+- [ ] 10-minute match reaches sudden-death and resolves.
 - [ ] Ctrl-C on host ends the match cleanly for guest with
       `opponent disconnected` overlay.
 - [ ] Wrong room code → "room not found" error, no crash.
 - [ ] Server unreachable → "cannot reach blocktxt server" within 5 s,
       clean process exit, cooked terminal.
-- [ ] `mp local` works fully offline (no network syscalls observed
-      via `dtruss` / `strace`).
+- [ ] Malicious-server dry run: point `--server` at a scripted server
+      that emits ANSI-laden `Error.detail`; terminal remains clean.
 
 ## 7. Team
 
 Veteran experts to hire for v0.2 multiplayer:
 
 - **Veteran real-time multiplayer game networking engineer (1)** —
-  lead for protocol, tick/sync model, garbage exchange, desync audit.
+  lead for protocol, tick/sync model, garbage exchange, desync audit,
+  ack-window/keyframe policy.
 - **Veteran Rust systems engineer (1)** — extracts `blocktxt-sim`
   crate, enforces no-std-like purity (no clocks, no thread-locals),
-  owns `blocktxt-proto` codec and fuzzing.
+  owns `blocktxt-proto` codec, size caps, and fuzzing.
 - **Veteran async-Rust / tokio services engineer (1)** — builds
-  `blocktxt-server` (WS accept, matchmaker, match runner, graceful
-  shutdown, observability).
+  `blocktxt-server` (WS accept, admission, matchmaker, match runner,
+  graceful shutdown, observability).
 - **Veteran CLI / TUI engineer (1)** — wires `mp host` / `mp join`
-  subcommands, connection-status overlays, incoming-garbage HUD, and
+  subcommands, host-admit prompt, connection-status overlays,
+  incoming-garbage HUD, terminal-safe error rendering, and
   integrates the net thread with the existing render loop without
   breaking single-player cadence.
 - **Veteran application security engineer (0.5)** — reviews TLS
-  config, input validation, rate limits, and the threat model;
-  sign-off before public server goes live.
+  config, input validation, admission limits, terminal-escape
+  sanitization, IP-hash salt rotation, and the threat model; sign-off
+  before public server goes live.
 - **Veteran release/QA engineer (0.5)** — owns the manual multiplayer
-  test plan, cross-platform matrix, and the "does single-player still
-  work offline" regression gate.
+  test plan, cross-platform matrix (macOS arm64, macOS x86_64,
+  Linux x86_64), the nightly load-test job, and the "does
+  single-player still work offline" regression gate.
 
 Total: **4 full-time + 1 split** specialist hires on top of the
 existing maintainers.
@@ -422,61 +742,96 @@ with `→` for dependencies and `∥` for parallel work.
 ### Sprint 1 — Foundations (parallel everywhere)
 
 - Rust systems ∥ networking: extract `blocktxt-sim` crate, swap RNG
-  for `ChaCha20Rng`, delete all `Instant::now()` from sim. (TDD:
-  determinism property test first, red.)
+  for `ChaCha20Rng`, delete all `Instant::now()` from sim, remove
+  `dt` parameter. (TDD: determinism property test first, red.)
 - Networking ∥ Rust systems: draft `blocktxt-proto` frame catalogue
-  + round-trip tests (red → green).
+  including `Input` bit layout, size caps, round-trip tests
+  (red → green).
 - CLI: add `blocktxt mp --help` stub subcommand skeleton behind a
   compile-time `multiplayer` feature flag, defaulted *off* until
   Sprint 3 so main stays shippable.
-- Security: threat-model doc + `cargo deny` rules merged.
+- Security: threat-model doc + `cargo deny` rules + IP-hash salt
+  design merged.
 
-### Sprint 2 — Server & offline two-player
+### Sprint 2 — Server & internal harness
 
 - Async-tokio: `blocktxt-server` accepts TLS-terminated WS
-  connections, implements matchmaker with room codes, runs one
-  `sim::Match` per room at 60 Hz.
-- Networking → async-tokio: garbage-exchange logic lands in
-  `sim::Match`; server broadcasts snapshots.
-- CLI ∥: `blocktxt mp local` (two-player on one machine, no network)
-  ships as a dev aid and exercises the new `sim::Match` end-to-end.
+  connections, enforces all §4.4 limits, implements matchmaker with
+  room codes, runs one `sim::Match` per room at 60 Hz.
+- Networking → async-tokio: garbage-exchange logic (full §5.3 table,
+  sudden-death, RNG derivation) lands in `sim::Match`; server
+  implements ack window + keyframe policy + backpressure.
+- Rust systems ∥ CLI: `internal-harness` feature exercises
+  `sim::Match` end-to-end in a single process for integration tests.
 - QA: multiplayer manual test plan draft v1, reviewed.
 
 ### Sprint 3 — Online play & polish
 
-- CLI → networking: `mp host` / `mp join` wired to server; connection
-  overlays ("waiting for opponent", "connecting…", "peer
-  disconnected") rendered by TUI engineer.
-- Networking ∥ CLI: input-delay pipeline + snapshot mirror on client;
-  incoming-garbage HUD column in playfield view.
-- Security: penetration pass on deployed staging server (rate-limit
-  verification, TLS config audit, fuzzing).
-- Async-tokio ∥ QA: observability (match_id structured logs,
-  Prometheus `/metrics` endpoint for concurrent_matches and
-  tick_budget_p99).
-- CI: cross-arch determinism check, fuzz job, release artifact for
-  `blocktxt-server` (static musl binary).
+- CLI → networking: `mp host` / `mp join` wired to server; host-admit
+  prompt, connection overlays ("waiting for opponent", "connecting…",
+  "peer disconnected", "host declined"), terminal-safe error
+  rendering.
+- Networking ∥ CLI: input-delay pipeline, snapshot mirror, echo-ghost
+  on client; incoming-garbage HUD column with §5.3.4 thresholds.
+- Security: penetration pass on staging (rate-limit verification, TLS
+  audit, fuzzing, ANSI-injection dry run, IP-hash correlation check).
+- Async-tokio ∥ QA: observability (match_id structured logs with
+  keyed-hash IPs; Prometheus `/metrics` on 127.0.0.1:9090) and
+  nightly 200-match load test.
+- CI: cross-arch determinism check on three platforms, fuzz job,
+  release artifact for `blocktxt-server` (static musl binary).
 
 ### Sprint 4 — Release hardening
 
 - QA leads the manual matrix across macOS arm64, macOS x86_64,
   Linux x86_64; all veterans on-call for triage.
+- Load-test headline numbers (200 matches, bandwidth ≤ 8 KiB/s) must
+  pass on the target 1-vCPU / 512 MiB VM before sign-off.
 - Security sign-off before flipping DNS for the public server.
-- Docs: README multiplayer section, self-hosting guide.
+- Docs: README multiplayer section, self-hosting guide (including
+  metrics-exposure caveat).
 - Cut `blocktxt v0.2.0` + `blocktxt-server v0.1.0`.
 
 ## 9. Risks & mitigations
 
 | Risk                                     | Likelihood | Mitigation                                              |
 |------------------------------------------|------------|---------------------------------------------------------|
-| Simulation desync between arches         | Med        | Fixed-point only; CI digest check on macOS & Linux.     |
+| Simulation desync between arches         | Med        | Fixed-point only; CI digest check on three platforms.   |
 | Corporate networks block wss:443         | Low        | Use standard port; document HTTP_PROXY support.         |
-| Server cost balloons                     | Low        | Match cap of 10 min; 200 matches/VM; scale horizontally.|
+| Server cost balloons                     | Low        | Match cap of 10 min; admission cap 256 matches/node.    |
 | Single-player regresses                  | Med        | `multiplayer` feature is opt-in compile gate in Sprint 1–2; existing v0.1 manual test plan stays green every sprint. |
 | Room-code collision                      | Very low   | 33 M codes; matchmaker rejects live collisions.         |
+| Room-code hijack by brute force          | Low        | Host-admission step (§4.4) + `JoinRoom` bucket.         |
+| Single-node outage wipes live matches    | Med        | Accepted for v0.2 beta; clean `Goodbye(ServerRestart)` + v0.3 multi-node roadmap. |
+| ANSI escape injection via server strings | Low        | ASCII-only wire contract + client-side sanitizer (§4.5).|
+| Snapshot memory balloon on stalled peer  | Low        | Bounded 32-snapshot ring + 60-snapshot disconnect.      |
 
 ## 10. Changelog
 
-- v0.1 (this document) — initial scaffold: language/topology/sync/
-  transport/scale decided; architecture, protocol, tests, team,
-  4-sprint plan laid out; strict non-goals recorded.
+- v0.1 — initial scaffold: language/topology/sync/transport/scale
+  decided; architecture, protocol, tests, team, 4-sprint plan laid
+  out; strict non-goals recorded.
+- v0.2 — round-1 review response. Added host-admission join flow and
+  second-credential design; expanded abuse/resource controls
+  (HostRoom, session, room, frame-size, invalid-frame, idle-room,
+  admission-cap limits); defined bounded ack window + keyframe
+  policy + outbound queue depth + backpressure rules; pinned
+  single-node v0.2 deployment with v0.3 scale roadmap; bound
+  `/metrics` to localhost; required terminal-safe rendering of all
+  server strings and made `Error.detail` ASCII-only; defined keyed
+  rotating IP-hash salt; removed `mp local` from public CLI surface
+  (internal harness only); fixed architecture placeholder
+  contradiction; fixed RTT vs one-way budget to explicit RTT;
+  replaced snapshot-rate-limit restatement with bounded
+  ack-window/keyframe policy; completed garbage table (combos,
+  T-spins, perfect clear), replaced B2B ×1.5 with flat +1, defined
+  queue cap and drain-cap overflow; defined sudden-death mechanics
+  at 10-minute cap; added Ping frame alongside Pong and corrected
+  direction; removed `dt` parameter from `sim::Match::step`; pinned
+  garbage RNG derivation via blake3; pinned `Input` bit layout;
+  removed `capabilities` from `Hello` in v1; documented
+  `--server`-wins precedence over env var; defined HUD colour-ramp
+  thresholds; added automated tests for snapshot pipeline,
+  input-delay, heartbeat, bandwidth, rate-limits, SIGTERM, and
+  200-match load; added macOS x86_64 to determinism CI; defined
+  local echo-ghost render policy for active piece.

--- a/.samo/spec/multiplayer-v1/SPEC.md
+++ b/.samo/spec/multiplayer-v1/SPEC.md
@@ -58,9 +58,9 @@ over:
 - **Peer-to-peer with a host**: needs NAT traversal (STUN/TURN) and one
   peer becomes de-facto authoritative anyway — same cheating surface,
   worse UX.
-- **Pure lockstep**: elegant for identical-input games but Tetris has
-  independent boards; we'd still need a referee for garbage exchange,
-  at which point we're 80 % of the way to server-authoritative.
+- **Pure lockstep**: elegant for identical-input games but a falling-block
+  game has independent boards; we'd still need a referee for garbage
+  exchange, at which point we're 80 % of the way to server-authoritative.
 - **Rollback netcode**: premium experience but a full sprint of work
   we can defer until there's demand.
 
@@ -81,8 +81,8 @@ with the tick budget below.
   scores, incoming-garbage queues, active pieces, phase). Snapshots
   are delta-compressed against the last-acked snapshot per client.
 - No client-side prediction in v1: on LAN / sub-50 ms RTT the
-  round-trip + 2-tick input delay is imperceptible for Tetris-paced
-  play. Prediction is an explicit v2 lever if telemetry shows we need
+  round-trip + 2-tick input delay is imperceptible for falling-block-
+  game-paced play. Prediction is an explicit v2 lever if telemetry shows we need
   it.
 
 ### 2.4 Transport — TLS-terminated WebSocket, binary frames
@@ -129,8 +129,8 @@ with the tick budget below.
    background threads touching the internet, binary size unchanged
    beyond the added multiplayer code path.
 
-4. **Taylor the twitch player** (persona: competitive Tetris player
-   used to Puyo Puyo Tetris / TETR.IO). *Action:* clears a tetris
+4. **Taylor the twitch player** (persona: competitive falling-block
+   player used to Puyo Puyo and TETR.IO). *Action:* clears a quad
    (4-line) while their opponent has a full well. *Outcome:* opponent
    receives 4 garbage rows within one server tick of the flash-phase
    completing, and the garbage-incoming indicator in Taylor's HUD
@@ -280,7 +280,7 @@ them to a minimum tick gap of 1 even when acks stall.
 ### 5.3 Garbage exchange
 
 - Line clears produce `garbage_out = lines_cleared - 1` (standard
-  versus-Tetris rule; single clears send 0). B2B quads send 5.
+  standard versus-mode rule; single clears send 0). B2B quads send 5.
 - Garbage is queued per-recipient on the server. Before the
   recipient's next piece spawn, the server drains the queue by
   inserting up to 8 rows of garbage at the bottom of their board,

--- a/.samo/spec/multiplayer-v1/SPEC.md
+++ b/.samo/spec/multiplayer-v1/SPEC.md
@@ -1,0 +1,482 @@
+# blocktxt multiplayer — SPEC v0.1
+
+> **Scope note.** This document specifies the two-player competitive
+> multiplayer mode added to blocktxt in game version **v0.2**. The project
+> slug `multiplayer-v1` refers to the *first* version of the multiplayer
+> subsystem, not to a rewrite of v0.1 gameplay. Single-player v0.1
+> behaviour is unchanged and must continue to work offline.
+
+## 1. Goal & why it's needed
+
+**Goal.** Ship a head-to-head competitive mode where two human players,
+each in their own terminal, play simultaneous falling-block games against
+each other. Line clears by one player send garbage rows to the other
+player's well. First player to top-out (block-out or lock-out) loses.
+
+**Why this exists.** blocktxt v0.1 is a polished but strictly solitary
+experience. Competitive multiplayer is the single largest replayability
+multiplier we can add: it turns a 5-minute coffee-break toy into a
+social artifact you send to a friend. It also exercises a class of
+engineering — deterministic simulation, network protocols, matchmaking
+— that the repo has deliberately avoided so far, so v0.2 is the right
+moment to pay that cost once, cleanly, rather than bolting it on later.
+
+**Non-goals for this version (enforced strictly).**
+
+- **NOT a spectator / streaming feature.** No watch-only clients in v1.
+- **NOT a leaderboard / rating service.** Matches are ad-hoc; no Elo,
+  no persistent win/loss records beyond a local session counter.
+- **NOT a lobby / chat / social product.** Two players connect via a
+  short room code. No friends list, no chat UI, no profiles.
+- **NOT cross-version compatible.** v0.2 clients only talk to v0.2
+  servers and v0.2 peers. Version mismatch → clean refusal.
+- **NOT a replacement for single-player.** Single-player v0.1 remains
+  the default launch mode; multiplayer is opt-in via a subcommand.
+- **NOT >2 players.** No free-for-all, no teams. Exactly 2.
+
+## 2. Design decisions (resolved from interview)
+
+The interview left five questions as "decide for me". The chosen answers
+and their rationale are recorded below so future reviewers don't have to
+reverse-engineer them.
+
+### 2.1 Language — Rust (client + server)
+
+The client is already Rust; sharing the simulation crate between client
+and server is the single highest-leverage decision we can make. It
+makes bit-exact determinism trivial (same code, same RNG, same fixed-
+point math) and halves the test surface. Server uses `tokio` for async
+I/O; client keeps its existing blocking main loop and speaks to the
+network from a dedicated thread.
+
+### 2.2 Topology — authoritative central server ("relay + referee")
+
+The server runs the canonical simulation for *both* players at 60 Hz.
+Clients send inputs; server returns authoritative state diffs. Chosen
+over:
+
+- **Peer-to-peer with a host**: needs NAT traversal (STUN/TURN) and one
+  peer becomes de-facto authoritative anyway — same cheating surface,
+  worse UX.
+- **Pure lockstep**: elegant for identical-input games but Tetris has
+  independent boards; we'd still need a referee for garbage exchange,
+  at which point we're 80 % of the way to server-authoritative.
+- **Rollback netcode**: premium experience but a full sprint of work
+  we can defer until there's demand.
+
+Server is stateless between matches and horizontally scalable; a single
+$5/month VM comfortably hosts hundreds of concurrent matches at 60 Hz
+with the tick budget below.
+
+### 2.3 Sync model — server-authoritative fixed-tick, client input-forward with input delay
+
+- Fixed simulation tick: **60 Hz** (16.67 ms), matching the existing
+  single-player frame cadence.
+- Clients forward inputs with a monotonically increasing sequence
+  number plus the client tick they were pressed on.
+- Server applies inputs at **`client_tick + INPUT_DELAY`** where
+  `INPUT_DELAY = 2 ticks ≈ 33 ms`. This absorbs typical jitter without
+  visible lag and avoids the complexity of rollback.
+- Server broadcasts a **state snapshot** every tick (two boards,
+  scores, incoming-garbage queues, active pieces, phase). Snapshots
+  are delta-compressed against the last-acked snapshot per client.
+- No client-side prediction in v1: on LAN / sub-50 ms RTT the
+  round-trip + 2-tick input delay is imperceptible for Tetris-paced
+  play. Prediction is an explicit v2 lever if telemetry shows we need
+  it.
+
+### 2.4 Transport — TLS-terminated WebSocket, binary frames
+
+- WebSocket over TLS (`wss://`) on port **443**. Chosen for
+  firewall-friendliness (corporate / school networks), standard Rust
+  tooling (`tokio-tungstenite`), and because matchmaking and game
+  traffic share one connection.
+- Binary frames carry a compact framed protocol (see §4.3); no JSON on
+  the hot path.
+- TLS is mandatory: room codes travel over the wire, and we refuse to
+  teach users to type plaintext credentials into a terminal.
+
+### 2.5 Scale target — 2 players, 60 Hz, 150 ms RTT budget
+
+| Dimension          | v0.1 target                                        |
+|--------------------|----------------------------------------------------|
+| Players per match  | exactly 2                                          |
+| Server tick rate   | 60 Hz                                              |
+| Client frame rate  | 60 fps (unchanged)                                 |
+| RTT budget         | ≤ 150 ms one-way latency for "feels responsive"    |
+| Bandwidth / client | ≤ 8 KiB/s steady state (delta snapshots)           |
+| Concurrent matches | 200 per 1-vCPU / 512 MiB server                    |
+| Match duration cap | 10 minutes (hard cap; otherwise sudden-death)      |
+
+## 3. User stories
+
+1. **Casey the commuter** (persona: single-player regular, 30 min/day
+   on trains). *Action:* runs `blocktxt mp host`, reads aloud the
+   5-character room code to a friend on a call. *Outcome:* within 10
+   seconds both are playing head-to-head; no signup, no account, no
+   browser.
+
+2. **Riley the reviewer** (persona: rust-curious developer trying
+   blocktxt for the first time). *Action:* runs `blocktxt mp join
+   ABCDE` from a fresh install behind a corporate HTTP proxy.
+   *Outcome:* connection succeeds over port 443; if it fails, the CLI
+   prints an actionable error naming *which* step failed (DNS, TLS,
+   handshake, version-mismatch, room-not-found).
+
+3. **Sam the skeptic** (persona: privacy-conscious, offline-first).
+   *Action:* launches `blocktxt` with no arguments. *Outcome:* gets
+   exactly the v0.1 single-player experience, no network calls, no
+   background threads touching the internet, binary size unchanged
+   beyond the added multiplayer code path.
+
+4. **Taylor the twitch player** (persona: competitive Tetris player
+   used to Puyo Puyo Tetris / TETR.IO). *Action:* clears a tetris
+   (4-line) while their opponent has a full well. *Outcome:* opponent
+   receives 4 garbage rows within one server tick of the flash-phase
+   completing, and the garbage-incoming indicator in Taylor's HUD
+   shows pending rows they're about to send.
+
+5. **Jordan the judge** (persona: QA / release-blocking role).
+   *Action:* runs the manual multiplayer test plan against a release
+   candidate on macOS arm64 and Linux x86_64 simultaneously.
+   *Outcome:* can verify in under 15 minutes that matchmaking,
+   gameplay, disconnection, and clean shutdown all behave; any failure
+   maps to a specific checklist item.
+
+## 4. Architecture
+
+<!-- architecture:begin -->
+
+```text
+(architecture not yet specified)
+```
+
+<!-- architecture:end -->
+
+### 4.1 Components & boundaries
+
+```
+┌──────────────────── blocktxt client (Rust binary) ────────────────────┐
+│                                                                       │
+│  cli  ─▶  mode dispatch  ─▶  single-player loop (unchanged v0.1)      │
+│                      │                                                │
+│                      └───▶   mp::client  ──────────────┐              │
+│                                 │                       │             │
+│                                 ▼                       ▼             │
+│                          net thread (tokio)     render/input (main)   │
+│                                 │                       │             │
+│                                 └── shared state ◀──────┘             │
+│                                     (sim::SnapshotMirror)             │
+└─────────────────────────────────┬─────────────────────────────────────┘
+                                  │ wss://  (TLS 1.3, binary frames)
+                                  ▼
+┌──────────────────── blocktxt-server (new binary) ─────────────────────┐
+│                                                                       │
+│  ws accept ─▶ session ─▶ matchmaker (room code)                       │
+│                    │         │                                        │
+│                    └────────▶│  match ─▶ sim (60 Hz, authoritative)   │
+│                              │             │                          │
+│                              │             └─▶ snapshot diff          │
+│                              └───────────────▶ broadcast to 2 peers   │
+└───────────────────────────────────────────────────────────────────────┘
+```
+
+New crates / modules in the workspace:
+
+- `blocktxt-sim` (library, extracted from existing `src/game/`): pure,
+  deterministic simulation. No `Instant::now()`, no thread-local RNG,
+  no I/O. Shared verbatim between client and server.
+- `blocktxt-proto` (library): wire-format types, framing, version
+  constants, `Encode`/`Decode` traits.
+- `blocktxt` (existing binary): gains `mp host` / `mp join` /
+  `mp local` subcommands.
+- `blocktxt-server` (new binary): WebSocket listener, matchmaker,
+  match runner.
+
+### 4.2 Key abstractions
+
+- **`sim::Match`** — holds two `GameState` instances plus a shared
+  garbage exchange queue. Pure function: `step(inputs_a, inputs_b,
+  dt) -> (events_a, events_b, garbage_delta)`.
+- **`sim::DetRng`** — seeded ChaCha20 RNG, replaces `StdRng` in the
+  simulation crate. Both 7-bag generators are seeded from the match
+  seed so sequences are reproducible for replays / desync audits.
+- **`proto::Frame`** — tagged union of `Hello`, `HostRoom`,
+  `JoinRoom`, `RoomReady`, `MatchStart`, `Input`, `Snapshot`, `Ack`,
+  `Pong`, `Goodbye`, `Error`. Versioned by the `Hello` handshake.
+- **`client::SnapshotMirror`** — lock-free SPSC slot that the net
+  thread writes and the render thread reads each frame. One tick
+  behind at worst.
+- **`server::RoomCode`** — 5-character `Crockford-base32` code (no
+  `ILOU`); 32⁵ ≈ 33 M codes. Matchmaker rejects codes already live.
+
+### 4.3 Wire protocol (v1)
+
+All frames are length-prefixed (u16 big-endian) binary payloads inside
+WebSocket binary messages. Fields are little-endian `bincode` v2 with
+the `varint` codec. `proto_version = 1` is carried in `Hello` and any
+mismatch is fatal.
+
+| Tag | Name          | Fields (summary)                                  |
+|----:|---------------|---------------------------------------------------|
+| 0x01| Hello         | proto_version, client_build, capabilities         |
+| 0x02| HostRoom      | — (server assigns code)                           |
+| 0x03| JoinRoom      | code (5 bytes)                                    |
+| 0x04| RoomReady     | code, role (host/guest), peer_build               |
+| 0x05| MatchStart    | match_id, seed (u64), start_tick                  |
+| 0x06| Input         | client_tick, seq, bitset of Inputs                |
+| 0x07| Snapshot      | server_tick, ack_seq, delta-encoded state         |
+| 0x08| Ack           | ack_tick                                          |
+| 0x09| Pong          | echoed nonce, server_tick                         |
+| 0x0A| Goodbye       | reason (enum)                                     |
+| 0x0B| Error         | code, human-readable string                       |
+
+`Input` frames are idempotent and replay-safe (seq numbers). Snapshots
+are sent unconditionally every tick at 60 Hz; the server rate-limits
+them to a minimum tick gap of 1 even when acks stall.
+
+## 5. Implementation details
+
+### 5.1 Deterministic simulation
+
+- Extract `src/game/` into `blocktxt-sim`. Swap `StdRng` for
+  `ChaCha20Rng` seeded from the match seed.
+- Remove all `Instant::now()` from the simulation; time advances only
+  via `step(dt)` where `dt` is always exactly one tick on the server.
+- Add a property test: given the same seed and the same input stream,
+  two independent runs produce byte-identical `Match` state after N
+  ticks (N = 10 000).
+- The *client* continues to use a real clock for animations (juice,
+  spawn-fade, score rollup) — those are rendered from the mirrored
+  snapshot and never feed back into simulation.
+
+### 5.2 State transitions (client)
+
+```
+            ┌────────────┐  mp host / mp join   ┌────────────────┐
+            │   Title    │ ───────────────────▶ │   Connecting   │
+            └─────┬──────┘                      └───────┬────────┘
+                  │ any key (single-player)             │
+                  ▼                                     ▼
+            ┌────────────┐                      ┌────────────────┐
+            │  Playing   │                      │ WaitingForPeer │
+            │ (local v1) │                      └───────┬────────┘
+            └────────────┘                              │ RoomReady
+                                                        ▼
+                                                ┌────────────────┐
+                                                │  MatchStarting │ (3-2-1 countdown)
+                                                └───────┬────────┘
+                                                        ▼
+                                                ┌────────────────┐
+                                 ┌──────────────│   MatchPlaying │
+                                 │ disconnect   └───────┬────────┘
+                                 ▼                      │ GameOver event
+                           ┌────────────┐               ▼
+                           │   Aborted  │       ┌────────────────┐
+                           └────────────┘       │   MatchResult  │
+                                                └────────────────┘
+```
+
+### 5.3 Garbage exchange
+
+- Line clears produce `garbage_out = lines_cleared - 1` (standard
+  versus-Tetris rule; single clears send 0). B2B quads send 5.
+- Garbage is queued per-recipient on the server. Before the
+  recipient's next piece spawn, the server drains the queue by
+  inserting up to 8 rows of garbage at the bottom of their board,
+  with one random gap column per row (RNG seeded from match seed +
+  tick + recipient id, so deterministic).
+- Incoming-garbage indicator: a HUD column on the inboard side of the
+  playfield shows pending rows; same colour ramp as existing animation
+  DIM → OVERLAY → NEW_BEST as the queue grows.
+
+### 5.4 Disconnect & lag handling
+
+- Heartbeat: client sends `Pong(nonce)` every 500 ms; server replies.
+  No pong for 3 s → server declares the session stalled and awards
+  the match to the peer.
+- If the *peer* disconnects mid-match, the surviving client gets a
+  `Goodbye(PeerDisconnected)` and a win by default.
+- Clean shutdown: Ctrl-C / SIGTERM sends `Goodbye(UserQuit)` before
+  closing the socket.
+
+### 5.5 Security posture
+
+- TLS 1.3 only; `rustls` with the `ring` provider. No plaintext
+  fallback.
+- Room codes rate-limited: ≤ 10 `JoinRoom` attempts per IP per minute.
+- Server ignores client-supplied `server_tick` fields; tick is a
+  server-owned monotonic counter.
+- Server validates every client `Input` against the simulation — an
+  input that names a non-existent move (e.g. `HardDrop` during
+  `Phase::GameOver`) is silently dropped, not crash-inducing.
+- No persistent data about players is stored server-side. Logs are
+  match_id + truncated IP hash, 7-day retention.
+
+### 5.6 CLI surface
+
+```
+blocktxt                         # unchanged: single-player v0.1
+blocktxt mp host [--server URL]  # host a room, print room code, wait
+blocktxt mp join CODE [--server URL]
+blocktxt mp local                # two local players, split-screen TTY
+                                 #  (no network; dev aid and offline mode)
+```
+
+`--server` defaults to the compiled-in official URL; overridable for
+self-hosting. `BLOCKTXT_SERVER` env var is also honoured.
+
+## 6. Tests plan
+
+### 6.1 Red/green TDD — built test-first
+
+The following are written as failing tests *before* their implementation
+lands, per strict TDD:
+
+- **`sim::Match` determinism** — property test, 10 000 random input
+  sequences across two independent instances → identical state.
+- **`proto` round-trip** — for every frame variant, `decode(encode(x))
+  == x`; malformed bytes → specific `Error` variant (never panic).
+- **Version-mismatch refusal** — client with `proto_version = 2`
+  against server v1 receives `Error(VersionMismatch)` and exits with
+  status 3.
+- **Garbage exchange table** — `lines_cleared → garbage_out` matches
+  the specified table exactly, including B2B × 1.5 rounding.
+- **Room-code charset** — generated codes never contain `I`, `L`,
+  `O`, `U`; property test over 100 k samples.
+- **Tick-budget invariant** — server `step` for 2 active matches
+  completes in < 1 ms on the reference CI VM (criterion bench gated
+  as a test).
+
+### 6.2 Integration (green-path, written after the TDD pieces above)
+
+- **Loopback match**: spin up `blocktxt-server` on `127.0.0.1:0`,
+  connect two in-process clients, script a 30-second match, assert a
+  `MatchResult` event is emitted and both clients exit cleanly.
+- **Disconnect mid-match**: kill one client's socket; assert the
+  other receives `Goodbye(PeerDisconnected)` within 3 s.
+- **Corporate-proxy simulation**: run the loopback suite through
+  `mitmproxy` in forward mode to confirm wss:443 still works.
+- **TLS refusal**: plaintext `ws://` connection attempt → server
+  drops with clear error, no process crash.
+- **Cross-arch determinism**: run the determinism property test on
+  macOS arm64 and Linux x86_64 in CI; seeds must produce identical
+  SHA-256 digests of the final state.
+
+### 6.3 CI additions
+
+- New matrix entry: `cargo test -p blocktxt-sim -p blocktxt-proto
+  -p blocktxt-server`.
+- Fuzz target (`cargo-fuzz`) on `proto::decode` — 5-minute nightly
+  run; any panic fails the job.
+- `cargo deny check` gains an advisories gate for `rustls`, `tokio`,
+  `tokio-tungstenite`.
+
+### 6.4 Manual test plan (release-blocking)
+
+Extends `docs/manual-test-plan.md` with a **Multiplayer** section:
+
+- [ ] `mp host` prints a 5-char code; `mp join <code>` on a second
+      machine connects within 2 s.
+- [ ] Line clear on host inserts garbage on guest well within one
+      visible frame of flash-phase completion.
+- [ ] Ctrl-C on host ends the match cleanly for guest with
+      `opponent disconnected` overlay.
+- [ ] Wrong room code → "room not found" error, no crash.
+- [ ] Server unreachable → "cannot reach blocktxt server" within 5 s,
+      clean process exit, cooked terminal.
+- [ ] `mp local` works fully offline (no network syscalls observed
+      via `dtruss` / `strace`).
+
+## 7. Team
+
+Veteran experts to hire for v0.2 multiplayer:
+
+- **Veteran real-time multiplayer game networking engineer (1)** —
+  lead for protocol, tick/sync model, garbage exchange, desync audit.
+- **Veteran Rust systems engineer (1)** — extracts `blocktxt-sim`
+  crate, enforces no-std-like purity (no clocks, no thread-locals),
+  owns `blocktxt-proto` codec and fuzzing.
+- **Veteran async-Rust / tokio services engineer (1)** — builds
+  `blocktxt-server` (WS accept, matchmaker, match runner, graceful
+  shutdown, observability).
+- **Veteran CLI / TUI engineer (1)** — wires `mp host` / `mp join`
+  subcommands, connection-status overlays, incoming-garbage HUD, and
+  integrates the net thread with the existing render loop without
+  breaking single-player cadence.
+- **Veteran application security engineer (0.5)** — reviews TLS
+  config, input validation, rate limits, and the threat model;
+  sign-off before public server goes live.
+- **Veteran release/QA engineer (0.5)** — owns the manual multiplayer
+  test plan, cross-platform matrix, and the "does single-player still
+  work offline" regression gate.
+
+Total: **4 full-time + 1 split** specialist hires on top of the
+existing maintainers.
+
+## 8. Implementation plan (sprints)
+
+Each sprint is 1 calendar week. Ordering between specialists shown
+with `→` for dependencies and `∥` for parallel work.
+
+### Sprint 1 — Foundations (parallel everywhere)
+
+- Rust systems ∥ networking: extract `blocktxt-sim` crate, swap RNG
+  for `ChaCha20Rng`, delete all `Instant::now()` from sim. (TDD:
+  determinism property test first, red.)
+- Networking ∥ Rust systems: draft `blocktxt-proto` frame catalogue
+  + round-trip tests (red → green).
+- CLI: add `blocktxt mp --help` stub subcommand skeleton behind a
+  compile-time `multiplayer` feature flag, defaulted *off* until
+  Sprint 3 so main stays shippable.
+- Security: threat-model doc + `cargo deny` rules merged.
+
+### Sprint 2 — Server & offline two-player
+
+- Async-tokio: `blocktxt-server` accepts TLS-terminated WS
+  connections, implements matchmaker with room codes, runs one
+  `sim::Match` per room at 60 Hz.
+- Networking → async-tokio: garbage-exchange logic lands in
+  `sim::Match`; server broadcasts snapshots.
+- CLI ∥: `blocktxt mp local` (two-player on one machine, no network)
+  ships as a dev aid and exercises the new `sim::Match` end-to-end.
+- QA: multiplayer manual test plan draft v1, reviewed.
+
+### Sprint 3 — Online play & polish
+
+- CLI → networking: `mp host` / `mp join` wired to server; connection
+  overlays ("waiting for opponent", "connecting…", "peer
+  disconnected") rendered by TUI engineer.
+- Networking ∥ CLI: input-delay pipeline + snapshot mirror on client;
+  incoming-garbage HUD column in playfield view.
+- Security: penetration pass on deployed staging server (rate-limit
+  verification, TLS config audit, fuzzing).
+- Async-tokio ∥ QA: observability (match_id structured logs,
+  Prometheus `/metrics` endpoint for concurrent_matches and
+  tick_budget_p99).
+- CI: cross-arch determinism check, fuzz job, release artifact for
+  `blocktxt-server` (static musl binary).
+
+### Sprint 4 — Release hardening
+
+- QA leads the manual matrix across macOS arm64, macOS x86_64,
+  Linux x86_64; all veterans on-call for triage.
+- Security sign-off before flipping DNS for the public server.
+- Docs: README multiplayer section, self-hosting guide.
+- Cut `blocktxt v0.2.0` + `blocktxt-server v0.1.0`.
+
+## 9. Risks & mitigations
+
+| Risk                                     | Likelihood | Mitigation                                              |
+|------------------------------------------|------------|---------------------------------------------------------|
+| Simulation desync between arches         | Med        | Fixed-point only; CI digest check on macOS & Linux.     |
+| Corporate networks block wss:443         | Low        | Use standard port; document HTTP_PROXY support.         |
+| Server cost balloons                     | Low        | Match cap of 10 min; 200 matches/VM; scale horizontally.|
+| Single-player regresses                  | Med        | `multiplayer` feature is opt-in compile gate in Sprint 1–2; existing v0.1 manual test plan stays green every sprint. |
+| Room-code collision                      | Very low   | 33 M codes; matchmaker rejects live collisions.         |
+
+## 10. Changelog
+
+- v0.1 (this document) — initial scaffold: language/topology/sync/
+  transport/scale decided; architecture, protocol, tests, team,
+  4-sprint plan laid out; strict non-goals recorded.

--- a/.samo/spec/multiplayer-v1/TLDR.md
+++ b/.samo/spec/multiplayer-v1/TLDR.md
@@ -19,4 +19,4 @@
 
 ## Next action
 
-`samospec resume multiplayer-v1`
+`samospec iterate multiplayer-v1`

--- a/.samo/spec/multiplayer-v1/TLDR.md
+++ b/.samo/spec/multiplayer-v1/TLDR.md
@@ -1,0 +1,22 @@
+# TL;DR
+
+## Goal
+
+> **Scope note.** This document specifies the two-player competitive > multiplayer mode added to blocktxt in game version **v0.2**. The project > slug `multiplayer-v1` refers to the *first* version of the multiplayer > subsystem, not to a rewrite of v0.1 gameplay. Single-player v0.1 > behaviour is unchanged and must continue to work offline.
+
+## Scope summary
+
+- 1. Goal & why it's needed
+- 2. Design decisions (resolved from interview)
+- 3. User stories
+- 4. Architecture
+- 5. Implementation details
+- 6. Tests plan
+- 7. Team
+- 8. Implementation plan (sprints)
+- 9. Risks & mitigations
+- 10. Changelog
+
+## Next action
+
+`samospec resume multiplayer-v1`

--- a/.samo/spec/multiplayer-v1/architecture.json
+++ b/.samo/spec/multiplayer-v1/architecture.json
@@ -1,0 +1,5 @@
+{
+  "version": "1",
+  "nodes": [],
+  "edges": []
+}

--- a/.samo/spec/multiplayer-v1/changelog.md
+++ b/.samo/spec/multiplayer-v1/changelog.md
@@ -11,3 +11,5 @@
 ## v0.2 — 2026-04-24T04:15:20.730Z
 
 - Round 1 reviews applied (decisions — accepted: 29, rejected: 0, deferred: 0).
+
+- user-edit before round 2

--- a/.samo/spec/multiplayer-v1/changelog.md
+++ b/.samo/spec/multiplayer-v1/changelog.md
@@ -8,3 +8,6 @@
 - user-edit before round 1
 
 - user-edit before round 1
+## v0.2 — 2026-04-24T04:15:20.730Z
+
+- Round 1 reviews applied (decisions — accepted: 29, rejected: 0, deferred: 0).

--- a/.samo/spec/multiplayer-v1/changelog.md
+++ b/.samo/spec/multiplayer-v1/changelog.md
@@ -6,3 +6,5 @@
 - Persona: Veteran "real-time multiplayer game networking engineer" expert
 
 - user-edit before round 1
+
+- user-edit before round 1

--- a/.samo/spec/multiplayer-v1/changelog.md
+++ b/.samo/spec/multiplayer-v1/changelog.md
@@ -1,0 +1,6 @@
+# changelog
+
+## v0.1 — 2026-04-24T03:59:03.348Z
+
+- Initial draft authored by the lead.
+- Persona: Veteran "real-time multiplayer game networking engineer" expert

--- a/.samo/spec/multiplayer-v1/changelog.md
+++ b/.samo/spec/multiplayer-v1/changelog.md
@@ -4,3 +4,5 @@
 
 - Initial draft authored by the lead.
 - Persona: Veteran "real-time multiplayer game networking engineer" expert
+
+- user-edit before round 1

--- a/.samo/spec/multiplayer-v1/context.json
+++ b/.samo/spec/multiplayer-v1/context.json
@@ -1,0 +1,747 @@
+{
+  "phase": "draft",
+  "files": [
+    {
+      "path": "README.md",
+      "bytes": 3234,
+      "tokens": 804,
+      "blob": "9eda6fd2640ec6571928d92f393260b3d1f998f5",
+      "included": true,
+      "risk_flags": []
+    },
+    {
+      "path": "Cargo.toml",
+      "bytes": 1019,
+      "tokens": 255,
+      "blob": "2b6888fc75254582c1125bea541bc3655a8a495f",
+      "included": true,
+      "risk_flags": []
+    },
+    {
+      "path": "docs/manual-test-plan.md",
+      "bytes": 2269,
+      "tokens": 564,
+      "blob": "6f1e320f06fdb2fdd48a1ddbc65dfeb1038376e8",
+      "included": true,
+      "risk_flags": []
+    },
+    {
+      "path": "src/game/state.rs",
+      "bytes": 32191,
+      "tokens": 7411,
+      "blob": "126d986201f29c7e9e895acb67ba4259e8b38405",
+      "included": true,
+      "risk_flags": []
+    },
+    {
+      "path": "src/main.rs",
+      "bytes": 14260,
+      "tokens": 3506,
+      "blob": "b81f945dc03cc321b3c6bc3f5faea38e02b8442a",
+      "included": true,
+      "risk_flags": []
+    },
+    {
+      "path": "src/persistence.rs",
+      "bytes": 12796,
+      "tokens": 3009,
+      "blob": "c1c8151d723543b00636df8044e7c41ce35b1105",
+      "included": true,
+      "risk_flags": []
+    },
+    {
+      "path": "src/render/hud.rs",
+      "bytes": 11504,
+      "tokens": 2874,
+      "blob": "8b6d82b4eb168823aeed5e4ceb8d03f88a5da0d3",
+      "included": true,
+      "risk_flags": []
+    },
+    {
+      "path": "src/render/mod.rs",
+      "bytes": 4668,
+      "tokens": 1166,
+      "blob": "48f30f5e431b223e8b499ef026a881b9b695633d",
+      "included": true,
+      "risk_flags": []
+    },
+    {
+      "path": "src/render/title.rs",
+      "bytes": 8554,
+      "tokens": 1738,
+      "blob": "ae3ab0e4e0279d400cf782536024dd04af4995c7",
+      "included": true,
+      "risk_flags": []
+    },
+    {
+      "path": "tests/anim.rs",
+      "bytes": 8205,
+      "tokens": 1928,
+      "blob": "22b64ecaf03415545199c8cc5bc0803c40770b93",
+      "included": true,
+      "risk_flags": []
+    },
+    {
+      "path": "tests/headless_gameloop.rs",
+      "bytes": 3159,
+      "tokens": 788,
+      "blob": "7560da57bc61e94552b5f2039e7e9dca85f12f46",
+      "included": true,
+      "risk_flags": []
+    },
+    {
+      "path": "tests/juice.rs",
+      "bytes": 12208,
+      "tokens": 2928,
+      "blob": "b5ca384dfed66707f3b5b2f050091aaf3739b2ac",
+      "included": true,
+      "risk_flags": []
+    },
+    {
+      "path": "tests/render_snapshots.rs",
+      "bytes": 11847,
+      "tokens": 2882,
+      "blob": "95d97fd746ab6a75cc6b991c4eeae377412247d3",
+      "included": true,
+      "risk_flags": []
+    },
+    {
+      "path": "tests/resize.rs",
+      "bytes": 3690,
+      "blob": "b76a6ecdf2f941c261623ca0a6005e10e91ca5a8",
+      "included": false,
+      "gist_id": "b76a6ecdf2f941c261623ca0a6005e10e91ca5a8.md",
+      "risk_flags": []
+    },
+    {
+      "path": "tests/snapshots/render_snapshots__board_view_catppuccin_via_arg.snap",
+      "bytes": 873,
+      "tokens": 147,
+      "blob": "39a26d4294c750e5608f635c074da8741e7ab347",
+      "included": true,
+      "risk_flags": []
+    },
+    {
+      "path": "tests/snapshots/render_snapshots__game_over_overlay_regular.snap",
+      "bytes": 562,
+      "blob": "34b7cf0296da097c81969d0a4b95333e4d45c44d",
+      "included": false,
+      "gist_id": "34b7cf0296da097c81969d0a4b95333e4d45c44d.md",
+      "risk_flags": []
+    },
+    {
+      "path": "tests/snapshots/render_snapshots__hud_with_score.snap",
+      "bytes": 572,
+      "blob": "ad0768f51439281c2f7504369824de63494ce599",
+      "included": false,
+      "gist_id": "ad0768f51439281c2f7504369824de63494ce599.md",
+      "risk_flags": []
+    },
+    {
+      "path": "tests/snapshots/render_snapshots__line_clear_flash_frame.snap",
+      "bytes": 793,
+      "blob": "5c69ea81699a5f78c232983032cd414239d62970",
+      "included": false,
+      "gist_id": "5c69ea81699a5f78c232983032cd414239d62970.md",
+      "risk_flags": []
+    },
+    {
+      "path": "tests/snapshots/resize__minimum_viable_size.snap",
+      "bytes": 1780,
+      "blob": "7cc3df77472d18c763fb23891d0df376f254a61c",
+      "included": false,
+      "gist_id": "7cc3df77472d18c763fb23891d0df376f254a61c.md",
+      "risk_flags": []
+    },
+    {
+      "path": "tests/snapshots/resize__normal_size.snap",
+      "bytes": 2500,
+      "blob": "c7dda256d9a70e17741819c1955b42117c59ff1d",
+      "included": false,
+      "gist_id": "c7dda256d9a70e17741819c1955b42117c59ff1d.md",
+      "risk_flags": []
+    },
+    {
+      "path": "tests/snapshots/title_screen__render_tests__title_empty_leaderboard.snap",
+      "bytes": 2765,
+      "blob": "4bad76fd3959fe9d202f839bb81b740b6048ec99",
+      "included": false,
+      "gist_id": "4bad76fd3959fe9d202f839bb81b740b6048ec99.md",
+      "risk_flags": []
+    },
+    {
+      "path": "tests/snapshots/title_screen__render_tests__title_with_scores.snap",
+      "bytes": 2769,
+      "blob": "359620a2dc8b7b5221c4b82a697e40329675511c",
+      "included": false,
+      "gist_id": "359620a2dc8b7b5221c4b82a697e40329675511c.md",
+      "risk_flags": []
+    },
+    {
+      "path": "tests/state.rs",
+      "bytes": 16676,
+      "blob": "f722cf351bc2784a4a2be707679a098504d1fddf",
+      "included": false,
+      "gist_id": "f722cf351bc2784a4a2be707679a098504d1fddf.md",
+      "risk_flags": []
+    },
+    {
+      "path": "tests/title_screen.rs",
+      "bytes": 7998,
+      "blob": "cd82a6ecb31963b891fab85dfaf74c357973a112",
+      "included": false,
+      "gist_id": "cd82a6ecb31963b891fab85dfaf74c357973a112.md",
+      "risk_flags": []
+    },
+    {
+      "path": "src/lib.rs",
+      "bytes": 326,
+      "blob": "234da341fbce9e7133ce14a97cb96fc4e1dae7eb",
+      "included": false,
+      "gist_id": "234da341fbce9e7133ce14a97cb96fc4e1dae7eb.md",
+      "risk_flags": []
+    },
+    {
+      "path": "src/render/board_view.rs",
+      "bytes": 8702,
+      "blob": "bd42b73fd9308f7f0de356a7bcf81e532434c630",
+      "included": false,
+      "gist_id": "bd42b73fd9308f7f0de356a7bcf81e532434c630.md",
+      "risk_flags": []
+    },
+    {
+      "path": "src/cli.rs",
+      "bytes": 4267,
+      "blob": "1a2bb266c6554a5369277e7986ad93ffee725ef5",
+      "included": false,
+      "gist_id": "1a2bb266c6554a5369277e7986ad93ffee725ef5.md",
+      "risk_flags": []
+    },
+    {
+      "path": "src/render/theme.rs",
+      "bytes": 11470,
+      "blob": "41e7096debd0bbfe72eb7080100779e746b149de",
+      "included": false,
+      "gist_id": "41e7096debd0bbfe72eb7080100779e746b149de.md",
+      "risk_flags": []
+    },
+    {
+      "path": "tests/theme.rs",
+      "bytes": 5098,
+      "blob": "d4f4da53776c5ce969f54f8c77dd5b33915e9f1d",
+      "included": false,
+      "gist_id": "d4f4da53776c5ce969f54f8c77dd5b33915e9f1d.md",
+      "risk_flags": []
+    },
+    {
+      "path": ".github/workflows/release.yml",
+      "bytes": 3327,
+      "blob": "dee428da4a5a7694446d0bc4c4c619f0bb6886a3",
+      "included": false,
+      "gist_id": "dee428da4a5a7694446d0bc4c4c619f0bb6886a3.md",
+      "risk_flags": []
+    },
+    {
+      "path": "scripts/bump-version.sh",
+      "bytes": 3064,
+      "blob": "0efa878591c6cdaf5593a2bd6b13e0620dc51905",
+      "included": false,
+      "gist_id": "0efa878591c6cdaf5593a2bd6b13e0620dc51905.md",
+      "risk_flags": []
+    },
+    {
+      "path": "scripts/check-naming.sh",
+      "bytes": 1271,
+      "blob": "3f43f880f85726d87e1ca36ef54fb2c2905ca4ec",
+      "included": false,
+      "gist_id": "3f43f880f85726d87e1ca36ef54fb2c2905ca4ec.md",
+      "risk_flags": []
+    },
+    {
+      "path": "tests/cli.rs",
+      "bytes": 8883,
+      "blob": "f514d75614d7c337a7efd66bb4dbda468766e408",
+      "included": false,
+      "gist_id": "f514d75614d7c337a7efd66bb4dbda468766e408.md",
+      "risk_flags": []
+    },
+    {
+      "path": "tests/snapshots/render_snapshots__board_view_empty.snap",
+      "bytes": 769,
+      "blob": "11a3b6f47739058aa4ca1f15bdca010c6d5e5267",
+      "included": false,
+      "gist_id": "11a3b6f47739058aa4ca1f15bdca010c6d5e5267.md",
+      "risk_flags": []
+    },
+    {
+      "path": "tests/snapshots/render_snapshots__board_view_with_active_piece_and_ghost.snap",
+      "bytes": 889,
+      "blob": "c26546887325f212edcdd35229ffd94453e5de21",
+      "included": false,
+      "gist_id": "c26546887325f212edcdd35229ffd94453e5de21.md",
+      "risk_flags": []
+    },
+    {
+      "path": "tests/snapshots/render_snapshots__board_view_with_locked_stack.snap",
+      "bytes": 953,
+      "blob": "6477cf24d6318d91f496a860bf5b8c765e450e25",
+      "included": false,
+      "gist_id": "6477cf24d6318d91f496a860bf5b8c765e450e25.md",
+      "risk_flags": []
+    },
+    {
+      "path": "tests/snapshots/render_snapshots__game_over_overlay_new_best.snap",
+      "bytes": 652,
+      "blob": "e1cc44f93298a55b3a1c30ca1491d724a7b98c1a",
+      "included": false,
+      "gist_id": "e1cc44f93298a55b3a1c30ca1491d724a7b98c1a.md",
+      "risk_flags": []
+    },
+    {
+      "path": "tests/snapshots/render_snapshots__hud_empty_state.snap",
+      "bytes": 572,
+      "blob": "225343d63c4b91fbe75ebbaabd25006683266653",
+      "included": false,
+      "gist_id": "225343d63c4b91fbe75ebbaabd25006683266653.md",
+      "risk_flags": []
+    },
+    {
+      "path": "tests/snapshots/render_snapshots__hud_no_color_mode.snap",
+      "bytes": 572,
+      "blob": "225343d63c4b91fbe75ebbaabd25006683266653",
+      "included": false,
+      "gist_id": "225343d63c4b91fbe75ebbaabd25006683266653.md",
+      "risk_flags": []
+    },
+    {
+      "path": "tests/snapshots/render_snapshots__hud_paused.snap",
+      "bytes": 604,
+      "blob": "9a0d279142d2331526bd2a2fef78ace8c060bebe",
+      "included": false,
+      "gist_id": "9a0d279142d2331526bd2a2fef78ace8c060bebe.md",
+      "risk_flags": []
+    },
+    {
+      "path": "tests/snapshots/resize__too_small_overlay.snap",
+      "bytes": 292,
+      "blob": "7493c6d61bc51f3f99d071678614c11d7caaeaad",
+      "included": false,
+      "gist_id": "7493c6d61bc51f3f99d071678614c11d7caaeaad.md",
+      "risk_flags": []
+    },
+    {
+      "path": "Justfile",
+      "bytes": 1757,
+      "blob": "4a9ac06a51f4770b496ffe3eb5c75531d060f95d",
+      "included": false,
+      "gist_id": "4a9ac06a51f4770b496ffe3eb5c75531d060f95d.md",
+      "risk_flags": []
+    },
+    {
+      "path": "CHANGELOG.md",
+      "bytes": 4288,
+      "blob": "1816f06886e81885c92e32c0af953a2e03621a75",
+      "included": false,
+      "gist_id": "1816f06886e81885c92e32c0af953a2e03621a75.md",
+      "risk_flags": []
+    },
+    {
+      "path": "tests/das_arr_stress.rs",
+      "bytes": 8452,
+      "blob": "5abcc1746ca36892e912439bae053da18ea90a78",
+      "included": false,
+      "gist_id": "5abcc1746ca36892e912439bae053da18ea90a78.md",
+      "risk_flags": []
+    },
+    {
+      "path": "tests/e2e_gameplay.rs",
+      "bytes": 8371,
+      "blob": "023168fa0d87e6b7c8745f55006635c8e2b2cd34",
+      "included": false,
+      "gist_id": "023168fa0d87e6b7c8745f55006635c8e2b2cd34.md",
+      "risk_flags": []
+    },
+    {
+      "path": "tests/persistence_regression.rs",
+      "bytes": 7881,
+      "blob": "972af04d44b65fe8042427d6dfa35259ba85ffd8",
+      "included": false,
+      "gist_id": "972af04d44b65fe8042427d6dfa35259ba85ffd8.md",
+      "risk_flags": []
+    },
+    {
+      "path": "tests/signal_lifecycle_rexpect.rs",
+      "bytes": 4511,
+      "blob": "fc22d897764c04a5dd6c1b6b553f7fe0c209a63f",
+      "included": false,
+      "gist_id": "fc22d897764c04a5dd6c1b6b553f7fe0c209a63f.md",
+      "risk_flags": []
+    },
+    {
+      "path": "tests/terminal_lifecycle.rs",
+      "bytes": 5736,
+      "blob": "983424a47b2ddfff590d01b0ec7278ac77d66c75",
+      "included": false,
+      "gist_id": "983424a47b2ddfff590d01b0ec7278ac77d66c75.md",
+      "risk_flags": []
+    },
+    {
+      "path": ".samo/spec/blocktxt-1/SPEC.md",
+      "bytes": 44617,
+      "blob": "728f9306a6ebd5a74bfb85024b0f9adb7d046042",
+      "included": false,
+      "gist_id": "728f9306a6ebd5a74bfb85024b0f9adb7d046042.md",
+      "risk_flags": []
+    },
+    {
+      "path": "tests/persistence.rs",
+      "bytes": 11866,
+      "blob": "6af5bac12f0c690bfb5a62ba93f11284d3a2a986",
+      "included": false,
+      "gist_id": "6af5bac12f0c690bfb5a62ba93f11284d3a2a986.md",
+      "risk_flags": []
+    },
+    {
+      "path": "src/input.rs",
+      "bytes": 12798,
+      "blob": "fd3bd30faba1c8b350e7bc97daaf091c31f7fdd0",
+      "included": false,
+      "gist_id": "fd3bd30faba1c8b350e7bc97daaf091c31f7fdd0.md",
+      "risk_flags": []
+    },
+    {
+      "path": "tests/das_arr.rs",
+      "bytes": 8825,
+      "blob": "997908b2ed271fdffc9b609f2ed2d46af3efcc5d",
+      "included": false,
+      "gist_id": "997908b2ed271fdffc9b609f2ed2d46af3efcc5d.md",
+      "risk_flags": []
+    },
+    {
+      "path": "tests/persistence_integration.rs",
+      "bytes": 6292,
+      "blob": "cebb5b7e5b3ed583cb1fb113365a0df28febed5c",
+      "included": false,
+      "gist_id": "cebb5b7e5b3ed583cb1fb113365a0df28febed5c.md",
+      "risk_flags": []
+    },
+    {
+      "path": ".samo/spec/blocktxt-1/TLDR.md",
+      "bytes": 324,
+      "blob": "2c63960c85bb090e13dee6a8449c064dd5dabfcf",
+      "included": false,
+      "gist_id": "2c63960c85bb090e13dee6a8449c064dd5dabfcf.md",
+      "risk_flags": []
+    },
+    {
+      "path": ".samo/spec/blocktxt-1/architecture.json",
+      "bytes": 51,
+      "blob": "f46cd6309bdb47c84722cf29c1b07dc9f5596aac",
+      "included": false,
+      "gist_id": "f46cd6309bdb47c84722cf29c1b07dc9f5596aac.md",
+      "risk_flags": []
+    },
+    {
+      "path": ".samo/spec/blocktxt-1/changelog.md",
+      "bytes": 446,
+      "blob": "b37753c15a2df694061aa092ad4d37b60b434137",
+      "included": false,
+      "gist_id": "b37753c15a2df694061aa092ad4d37b60b434137.md",
+      "risk_flags": []
+    },
+    {
+      "path": ".samo/spec/blocktxt-1/context.json",
+      "bytes": 985,
+      "blob": "4f469c374f8a6dd37d6622b8db0330c7f65e1903",
+      "included": false,
+      "gist_id": "4f469c374f8a6dd37d6622b8db0330c7f65e1903.md",
+      "risk_flags": []
+    },
+    {
+      "path": ".samo/spec/blocktxt-1/decisions.md",
+      "bytes": 8295,
+      "blob": "284936e8cf95290a176123608106c326e0c9c1fb",
+      "included": false,
+      "gist_id": "284936e8cf95290a176123608106c326e0c9c1fb.md",
+      "risk_flags": []
+    },
+    {
+      "path": ".samo/spec/blocktxt-1/interview.json",
+      "bytes": 3039,
+      "blob": "552d55fb58913d6bed2a85f67096e6e45fef803d",
+      "included": false,
+      "gist_id": "552d55fb58913d6bed2a85f67096e6e45fef803d.md",
+      "risk_flags": []
+    },
+    {
+      "path": ".samo/spec/blocktxt-1/reviews/r01/claude.md",
+      "bytes": 13956,
+      "blob": "6950c455cf7ab0c1febdb9777c638258fe6be82b",
+      "included": false,
+      "gist_id": "6950c455cf7ab0c1febdb9777c638258fe6be82b.md",
+      "risk_flags": []
+    },
+    {
+      "path": ".samo/spec/blocktxt-1/reviews/r01/codex.md",
+      "bytes": 8592,
+      "blob": "a27e417cbf7bde2b6d558050ec2c21ff40323412",
+      "included": false,
+      "gist_id": "a27e417cbf7bde2b6d558050ec2c21ff40323412.md",
+      "risk_flags": []
+    },
+    {
+      "path": ".samo/spec/blocktxt-1/reviews/r01/round.json",
+      "bytes": 882,
+      "blob": "6071f7d4b3b313eded3c4578e49464e934eff090",
+      "included": false,
+      "gist_id": "6071f7d4b3b313eded3c4578e49464e934eff090.md",
+      "risk_flags": []
+    },
+    {
+      "path": ".samo/spec/blocktxt-1/reviews/r02/claude.md",
+      "bytes": 15149,
+      "blob": "cd2eb085148f2af32d917819dde3a609d6d5d144",
+      "included": false,
+      "gist_id": "cd2eb085148f2af32d917819dde3a609d6d5d144.md",
+      "risk_flags": []
+    },
+    {
+      "path": ".samo/spec/blocktxt-1/reviews/r02/codex.md",
+      "bytes": 11044,
+      "blob": "ea2cee29968bc2662b9f688f340999ec3bbc2010",
+      "included": false,
+      "gist_id": "ea2cee29968bc2662b9f688f340999ec3bbc2010.md",
+      "risk_flags": []
+    },
+    {
+      "path": ".samo/spec/blocktxt-1/reviews/r02/round.json",
+      "bytes": 196,
+      "blob": "c51e6d18216572002b8a4ae2585d084b750ba1fd",
+      "included": false,
+      "gist_id": "c51e6d18216572002b8a4ae2585d084b750ba1fd.md",
+      "risk_flags": []
+    },
+    {
+      "path": ".samo/spec/blocktxt-1/state.json",
+      "bytes": 1135,
+      "blob": "637c608e612194a874ff826c995882528407065d",
+      "included": false,
+      "gist_id": "637c608e612194a874ff826c995882528407065d.md",
+      "risk_flags": []
+    },
+    {
+      "path": "src/game/bag.rs",
+      "bytes": 1649,
+      "blob": "3d8820e381a896da4c6385e5a900450913e0910a",
+      "included": false,
+      "gist_id": "3d8820e381a896da4c6385e5a900450913e0910a.md",
+      "risk_flags": []
+    },
+    {
+      "path": "src/game/rules.rs",
+      "bytes": 7275,
+      "blob": "f9d62c57b6cc99ea0357485a1ea2a925f348db15",
+      "included": false,
+      "gist_id": "f9d62c57b6cc99ea0357485a1ea2a925f348db15.md",
+      "risk_flags": []
+    },
+    {
+      "path": "tests/srs_rotation.rs",
+      "bytes": 8600,
+      "blob": "0ca5d822663b2e75c14f71628f65cbec9ae1dd04",
+      "included": false,
+      "gist_id": "0ca5d822663b2e75c14f71628f65cbec9ae1dd04.md",
+      "risk_flags": []
+    },
+    {
+      "path": "src/game/board.rs",
+      "bytes": 3008,
+      "blob": "db5d7bac6e40943169763d67f0593d2ce41377af",
+      "included": false,
+      "gist_id": "db5d7bac6e40943169763d67f0593d2ce41377af.md",
+      "risk_flags": []
+    },
+    {
+      "path": "src/render/helpers.rs",
+      "bytes": 2653,
+      "blob": "55edb4b62fe1443a2caed4d2e81fb8d9135cf61e",
+      "included": false,
+      "gist_id": "55edb4b62fe1443a2caed4d2e81fb8d9135cf61e.md",
+      "risk_flags": []
+    },
+    {
+      "path": "tests/render_helpers.rs",
+      "bytes": 4380,
+      "blob": "2c6c96a0a0f37465d2a243685df196b6539f05c7",
+      "included": false,
+      "gist_id": "2c6c96a0a0f37465d2a243685df196b6539f05c7.md",
+      "risk_flags": []
+    },
+    {
+      "path": "src/game/mod.rs",
+      "bytes": 86,
+      "blob": "c967dd98166f16bd990cafdba7a4693ffcebe56a",
+      "included": false,
+      "gist_id": "c967dd98166f16bd990cafdba7a4693ffcebe56a.md",
+      "risk_flags": []
+    },
+    {
+      "path": "tests/rules.rs",
+      "bytes": 7260,
+      "blob": "d6d7e912401120caf6e190114a4d815d3cbf961b",
+      "included": false,
+      "gist_id": "d6d7e912401120caf6e190114a4d815d3cbf961b.md",
+      "risk_flags": []
+    },
+    {
+      "path": "src/game/piece.rs",
+      "bytes": 8655,
+      "blob": "00b1cb647930b6fa650aa69c8e7662f07ea6d12e",
+      "included": false,
+      "gist_id": "00b1cb647930b6fa650aa69c8e7662f07ea6d12e.md",
+      "risk_flags": []
+    },
+    {
+      "path": "src/game/srs.rs",
+      "bytes": 7537,
+      "blob": "c6ba964df2a3f20efb9a1007c742d30edef3a1a7",
+      "included": false,
+      "gist_id": "c6ba964df2a3f20efb9a1007c742d30edef3a1a7.md",
+      "risk_flags": []
+    },
+    {
+      "path": "src/clock.rs",
+      "bytes": 2196,
+      "blob": "82dde58a501229beedbe0027c32c3a409d78cdf9",
+      "included": false,
+      "gist_id": "82dde58a501229beedbe0027c32c3a409d78cdf9.md",
+      "risk_flags": []
+    },
+    {
+      "path": "tests/clock.rs",
+      "bytes": 1820,
+      "blob": "37f951c3aad6af38fe16a05405ca3950848f0892",
+      "included": false,
+      "gist_id": "37f951c3aad6af38fe16a05405ca3950848f0892.md",
+      "risk_flags": []
+    },
+    {
+      "path": "tests/bag.rs",
+      "bytes": 5990,
+      "blob": "f5d1f522f86bbc980d9137e104ed152ff18d8b4c",
+      "included": false,
+      "gist_id": "f5d1f522f86bbc980d9137e104ed152ff18d8b4c.md",
+      "risk_flags": []
+    },
+    {
+      "path": "tests/board.rs",
+      "bytes": 2883,
+      "blob": "fa7fca0bbb2b16215dcbf63be83d94586f3578d2",
+      "included": false,
+      "gist_id": "fa7fca0bbb2b16215dcbf63be83d94586f3578d2.md",
+      "risk_flags": []
+    },
+    {
+      "path": "tests/piece.rs",
+      "bytes": 1756,
+      "blob": "af8b80b2182c08818ae5c45fe4ab3dd79eeef330",
+      "included": false,
+      "gist_id": "af8b80b2182c08818ae5c45fe4ab3dd79eeef330.md",
+      "risk_flags": []
+    },
+    {
+      "path": "src/signals.rs",
+      "bytes": 2192,
+      "blob": "9adc059b33d80266711828bc3f096963acdd5d46",
+      "included": false,
+      "gist_id": "9adc059b33d80266711828bc3f096963acdd5d46.md",
+      "risk_flags": []
+    },
+    {
+      "path": "src/terminal.rs",
+      "bytes": 6373,
+      "blob": "37c636ffe7815fc7f637740eaed6304907b7d438",
+      "included": false,
+      "gist_id": "37c636ffe7815fc7f637740eaed6304907b7d438.md",
+      "risk_flags": []
+    },
+    {
+      "path": ".github/workflows/ci.yml",
+      "bytes": 1170,
+      "blob": "ef3f6a0dbbe33607babb1f58173358234810fc75",
+      "included": false,
+      "gist_id": "ef3f6a0dbbe33607babb1f58173358234810fc75.md",
+      "risk_flags": []
+    },
+    {
+      "path": ".gitignore",
+      "bytes": 8,
+      "blob": "ea8c4bf7f35f6f77f75d92ad8ce8349f6e81ddba",
+      "included": false,
+      "gist_id": "ea8c4bf7f35f6f77f75d92ad8ce8349f6e81ddba.md",
+      "risk_flags": []
+    },
+    {
+      "path": "deny.toml",
+      "bytes": 9789,
+      "blob": "9300aeda7ca68e1489b6dc910086d1967ae5bd41",
+      "included": false,
+      "gist_id": "9300aeda7ca68e1489b6dc910086d1967ae5bd41.md",
+      "risk_flags": []
+    },
+    {
+      "path": "rust-toolchain.toml",
+      "bytes": 66,
+      "blob": "73cb934de4706a914c15e8db2a3c037ce75699d9",
+      "included": false,
+      "gist_id": "73cb934de4706a914c15e8db2a3c037ce75699d9.md",
+      "risk_flags": []
+    },
+    {
+      "path": ".samo/.gitignore",
+      "bytes": 69,
+      "blob": "d9950aaaf117f8af431711029ca05e8e264a6edf",
+      "included": false,
+      "gist_id": "d9950aaaf117f8af431711029ca05e8e264a6edf.md",
+      "risk_flags": []
+    },
+    {
+      "path": ".samo/config.json",
+      "bytes": 1181,
+      "blob": "76bd274e8954d39ab95992dbf92c4c2321f56737",
+      "included": false,
+      "gist_id": "76bd274e8954d39ab95992dbf92c4c2321f56737.md",
+      "risk_flags": []
+    },
+    {
+      "path": ".samo/spec/multiplayer-v1.archived-2026-04-24T035450Z/state.json",
+      "bytes": 2160,
+      "blob": "f7fbb869da35b459315cee56d57a7afd4c1e99bf",
+      "included": false,
+      "gist_id": "f7fbb869da35b459315cee56d57a7afd4c1e99bf.md",
+      "risk_flags": []
+    },
+    {
+      "path": ".samo/spec/multiplayer-v1.archived-2026-04-24T035903Z/state.json",
+      "bytes": 2160,
+      "blob": "acbdabd08ddc72d051a46f14cc96d727980966b8",
+      "included": false,
+      "gist_id": "acbdabd08ddc72d051a46f14cc96d727980966b8.md",
+      "risk_flags": []
+    },
+    {
+      "path": ".samo/spec/multiplayer-v1/state.json",
+      "bytes": 543,
+      "blob": "878e7ae1d79c23e8edf004acc6dff421f01d852e",
+      "included": false,
+      "gist_id": "878e7ae1d79c23e8edf004acc6dff421f01d852e.md",
+      "risk_flags": []
+    }
+  ],
+  "risk_flags": [],
+  "budget": {
+    "phase": "draft",
+    "tokens_used": 30000,
+    "tokens_budget": 30000
+  }
+}

--- a/.samo/spec/multiplayer-v1/decisions.md
+++ b/.samo/spec/multiplayer-v1/decisions.md
@@ -1,3 +1,35 @@
 # decisions
 
 - No review-loop decisions yet.
+
+## Round 1 — 2026-04-24T04:15:20.730Z
+
+- accepted missing-risk#1: Added §4.4 host-admission step (JoinRequest/HostDecision) so the 5-char code is no longer the only credential — host must explicitly approve each join.
+- accepted missing-risk#2: §4.4 now pins HostRoom, concurrent sessions/rooms per IP, idle-room lifetime, invalid-frame budget, and per-node caps as enforced limits.
+- accepted missing-risk#3: §2.5 and §4.4 add an explicit 256-match admission cap with ServerFull rejection and 1024-session TLS-accept cap so overload fails closed rather than degrading live matches.
+- accepted weak-implementation#1: §4.4 defines a 32-snapshot ring, keyframe fallback, 60-snapshot disconnect threshold, outbound queue depth of 8, and coalesce-on-backpressure — removes the unbounded path for a lagging client.
+- accepted missing-risk#4: §4.4 pins 16 KiB max WebSocket message, 64 KiB max decoded allocation, per-client frame rate, invalid-frame budget, and per-IP malformed-frame ban.
+- accepted missing-risk#5: §1, §2.2, and §4.6 now make v0.2 an explicit single-node single-region beta; horizontal scale + registry/sticky routing are a v0.3 workstream with an explicit restart-loses-matches behaviour and a clear upgrade path.
+- accepted missing-risk#6: §5.5.4 binds /metrics to 127.0.0.1:9090 and documents that self-hosters must supply their own proxy/auth for remote scraping.
+- accepted missing-risk#7: §4.5 mandates client-side stripping to printable ASCII + column cap; Error.detail is declared ASCII-only on the wire and validated both sides.
+- accepted unnecessary-scope#1: §5.6 removes `mp local` from the public CLI; the two-player single-process path now lives only behind the internal-harness cargo feature for CI use.
+- accepted weak-implementation#2: §5.5.3 specifies blake3(salt ∥ ip)[..8] with a 256-bit salt rotated every 24 h, previous 7 salts retained in memory only, raw IPs purged on session close, 7-day log retention.
+- accepted contradiction#1: §4 no longer contains the `(architecture not yet specified)` placeholder; the diagram and §4.1–4.6 are the only architecture content.
+- accepted contradiction#2: §2.5 now states 150 ms is round-trip (≈75 ms one-way) and §2.3's perceptibility claim references RTT explicitly.
+- accepted contradiction#3: Rewrote §2.3 and §4.4 to replace the self-restating rate-limit clause with a concrete bounded ack-window + keyframe + coalesce-on-backpressure policy.
+- accepted ambiguity#1: §5.3.1 gives a complete integer-only garbage table (single through perfect clear, combos, T-spins), replaces B2B ×1.5 with flat +1 to eliminate rounding questions, pins a 40-row queue cap with drop-behaviour and an 8-row drain cap.
+- accepted ambiguity#2: §5.3.2 defines sudden-death at tick 36000: drain cap raised, periodic drip garbage, height tiebreak, match_id parity final tiebreak.
+- accepted weak-testing#1: §6.1 adds TDD cases for snapshot delta/keyframe round-trip, ack-window boundary, input-delay pipeline, heartbeat stall auto-award, and ANSI sanitization.
+- accepted weak-testing#2: §6.2 adds a bandwidth-budget integration test (≤8 KiB/s mean, ≤32 KiB/s peak) and a nightly 200-match load-test job with explicit tick-budget and admission assertions.
+- accepted ambiguity#3: §4.3 introduces a distinct Ping (0x0C) frame from the client and Pong (0x0D) from the server, matching RFC 6455 directional semantics.
+- accepted ambiguity#4: §4.2 and §5.1 remove the `dt` parameter from `sim::Match::step`; each call advances exactly one tick with no other cadence permitted.
+- accepted ambiguity#5: §5.3.3 pins garbage RNG derivation to ChaCha20Rng::from_seed(blake3(match_seed ∥ recipient_id ∥ tick)[..32]) and flags it as part of the wire contract; §6.1 adds a golden-vector cross-arch test.
+- accepted ambiguity#6: §4.3 pins the u16 Input bit layout exhaustively; reserved bits must be zero and set reserved bits close the connection with Error(MalformedInput).
+- accepted ambiguity#7: §4.3 removes `capabilities` from Hello for v1; forward compatibility is handled strictly by proto_version bumps, removing a downgrade-attack surface.
+- accepted ambiguity#8: §5.6 now states that when both --server and BLOCKTXT_SERVER are set, --server wins, matching common CLI convention.
+- accepted ambiguity#9: §5.3.4 pins the pending-row HUD colour-ramp thresholds (0, 1–3 DIM, 4–7 OVERLAY, 8+ NEW_BEST, capped flashing at 4 Hz).
+- accepted weak-testing#3: §6.2 adds explicit rate-limit enforcement, admission-cap, and frame-size-enforcement integration tests, covering the previously-assertion-only §5.5 rules.
+- accepted weak-testing#4: §6.3 adds macOS x86_64 to the determinism CI matrix so the digest check covers every platform QA signs off on.
+- accepted weak-testing#5: §6.2 adds an automated SIGTERM graceful-shutdown test that spawns the binary, sends SIGTERM, and asserts Goodbye(UserQuit) plus zero exit within 2 s.
+- accepted ambiguity#10: §2.3 now specifies a local input-echo ghost for the player's own active piece only; well, opponent, lock, clear, and garbage are rendered strictly from the server snapshot, with explicit snap-to-server on divergence.
+- accepted missing-requirement#1: Acknowledged as informational — all nine mandatory baseline sections are present; no action required beyond noting it.

--- a/.samo/spec/multiplayer-v1/decisions.md
+++ b/.samo/spec/multiplayer-v1/decisions.md
@@ -1,0 +1,3 @@
+# decisions
+
+- No review-loop decisions yet.

--- a/.samo/spec/multiplayer-v1/interview.json
+++ b/.samo/spec/multiplayer-v1/interview.json
@@ -1,0 +1,98 @@
+{
+  "slug": "multiplayer-v1",
+  "persona": "Veteran \"real-time multiplayer game networking engineer\" expert",
+  "generated_at": "2026-04-24T03:59:03.348Z",
+  "questions": [
+    {
+      "id": "language",
+      "text": "Which implementation language should we use for the client and server runtime?",
+      "options": [
+        "Rust (single codebase client+server, strong perf)",
+        "C++ (industry-standard for realtime netcode)",
+        "Go (simple concurrency, server-authoritative)",
+        "TypeScript/Node (browser client + shared types)",
+        "C# (Unity-friendly, ENet/LiteNetLib ecosystem)",
+        "decide for me",
+        "not sure — defer",
+        "custom"
+      ]
+    },
+    {
+      "id": "topology",
+      "text": "What network topology and authority model should the game use?",
+      "options": [
+        "Dedicated authoritative server (client-server)",
+        "Listen-server (host-as-authority) with P2P clients",
+        "Full peer-to-peer with deterministic lockstep",
+        "Relayed P2P with one elected host",
+        "decide for me",
+        "not sure — defer",
+        "custom"
+      ]
+    },
+    {
+      "id": "sync-model",
+      "text": "Which state-synchronization model fits the gameplay best?",
+      "options": [
+        "Client prediction + server reconciliation + lag compensation",
+        "Deterministic lockstep (input-only sync)",
+        "Rollback netcode (GGPO-style)",
+        "Snapshot interpolation only (no prediction)",
+        "State replication with delta compression (Quake/Source-style)",
+        "decide for me",
+        "not sure — defer",
+        "custom"
+      ]
+    },
+    {
+      "id": "transport",
+      "text": "What transport layer should we target for the wire protocol?",
+      "options": [
+        "Custom UDP with reliability layer (ENet/laminar-style)",
+        "QUIC (reliable+unreliable streams, built-in encryption)",
+        "WebRTC DataChannels (browser-reachable, NAT traversal)",
+        "WebSockets over TCP (simplest, browser-friendly)",
+        "Raw UDP + TCP fallback",
+        "decide for me",
+        "not sure — defer",
+        "custom"
+      ]
+    },
+    {
+      "id": "scale-target",
+      "text": "What player count, tick rate, and latency budget define v0.1 success?",
+      "options": [
+        "2–4 players, 60Hz tick, <50ms RTT (competitive/fighting)",
+        "8–16 players, 30–64Hz tick, <80ms (shooter/arena)",
+        "32–64 players, 20–30Hz tick, <120ms (battle royale)",
+        "100+ players, 10–20Hz tick, <150ms (MMO-lite)",
+        "2 players only, 30Hz, best-effort latency (co-op prototype)",
+        "decide for me",
+        "not sure — defer",
+        "custom"
+      ]
+    }
+  ],
+  "answers": [
+    {
+      "id": "language",
+      "choice": "decide for me"
+    },
+    {
+      "id": "topology",
+      "choice": "decide for me"
+    },
+    {
+      "id": "sync-model",
+      "choice": "decide for me"
+    },
+    {
+      "id": "transport",
+      "choice": "decide for me"
+    },
+    {
+      "id": "scale-target",
+      "choice": "decide for me"
+    }
+  ]
+}

--- a/.samo/spec/multiplayer-v1/reviews/r01/claude.md
+++ b/.samo/spec/multiplayer-v1/reviews/r01/claude.md
@@ -2,40 +2,38 @@
 
 ## summary
 
-The spec covers all nine mandatory baseline sections and is strong on scope discipline, topology rationale, and sprint parallelisation. The most serious gaps are: (1) the §4 architecture placeholder contradicts the populated §4.1–4.3; (2) the Sprint-1 feature-flag rule contradicts Sprint 2 shipping `mp local`; (3) garbage-exchange prose (§5.3) does not match the B2B ×1.5 table referenced by its test (§6.1); (4) RTT-vs-one-way conflated in §2.5; (5) heartbeat uses `Pong` with no `Ping` frame defined. Multiple enums (Goodbye/Error reasons), the fixed-point arithmetic scheme, sudden-death rules, and garbage queue-overflow behaviour are referenced but never specified. Testing is weak on the load-bearing claims: bandwidth budget, 200-match scale target, adversarial input validation, rate limiting, and silent-stall heartbeat timeout all lack corresponding tests. No idea-contradiction findings — the original idea contains no explicit `NOT X` disclaimers to violate.
+Strong first draft: all nine mandatory sections are present, the non-goals are unusually disciplined, and the TDD-first test list exists. The main weaknesses are (a) a broken architecture placeholder that contradicts the real content, (b) a confused RTT-vs-one-way budget in §2.5 that undermines the sync-model justification, (c) underspecified garbage/B2B rules and undefined sudden-death behavior at the 10-minute cap, (d) missing automated coverage for the snapshot-delta pipeline, input-delay behavior, heartbeat stall-timeout, bandwidth, and 200-match concurrency claims, and (e) a set of smaller wire-protocol ambiguities (Ping vs Pong, Input bit layout, capabilities negotiation, delta encoding, garbage-RNG derivation) that must be pinned before a versioned v1 protocol can claim cross-implementation compatibility.
 
 ## contradiction
 
-- (major) §4 Architecture contains a placeholder block between `architecture:begin` and `architecture:end` that reads "(architecture not yet specified)" yet §4.1–4.3 provide a detailed architecture (component diagram, key abstractions, wire protocol). A mechanical reader (or template tool) honouring the marker block would conclude the architecture section is empty/unfilled. Either populate the marker block with the diagram from §4.1 or delete the placeholder; as written the two statements directly contradict each other.
-- (major) §8 Sprint 1 states the `multiplayer` feature flag is "defaulted *off* until Sprint 3 so main stays shippable", yet Sprint 2 ships `blocktxt mp local` as a user-facing dev aid. `mp local` lives inside the multiplayer subcommand tree and cannot ship in Sprint 2 if the flag only turns on in Sprint 3. Resolve by either flipping the flag in Sprint 2 or gating `mp local` behind a separate flag.
-- (major) §2.5 scale table labels the 150 ms budget as both RTT and one-way latency in the same row: `RTT budget | ≤ 150 ms one-way latency for "feels responsive"`. RTT (round-trip) and one-way are factor-of-2 different; the protocol's 2-tick input-delay argument in §2.3 only checks out under one interpretation. Pick one definition and use it consistently (the downstream heartbeat, input-delay, and manual-test thresholds all depend on it).
-- (major) §5.3 specifies garbage via formula `garbage_out = lines_cleared - 1` plus a single carve-out "B2B quads send 5", but §6.1 requires a test that `lines_cleared → garbage_out` matches "the specified table exactly, including B2B × 1.5 rounding". No such table and no ×1.5 rule appear anywhere in the spec. The test cannot be written against the current text; either add the full table (including B2B behaviour for triples/doubles and the ×1.5 rounding rule) or rewrite §6.1 to match the simple formula.
+- (major) §4 contains an architecture placeholder block that literally reads `(architecture not yet specified)` between the `<!-- architecture:begin -->` and `<!-- architecture:end -->` markers, directly contradicting the detailed content in §§4.1–4.3. Either the placeholder must be removed or the real diagram moved inside the block; as written, an automated doc-generator reading only the marked region will emit `architecture not yet specified` for a spec that does in fact specify architecture.
+- (major) §2.5 table row reads: `| RTT budget | ≤ 150 ms one-way latency for "feels responsive" |`. RTT (round-trip time) and one-way latency are different quantities; the budget can be one or the other but not both. This is load-bearing for §2.3's claim that RTT + 2-tick input delay is imperceptible — if the real target is 150 ms one-way (i.e. 300 ms RTT) the perceptibility claim is wrong.
+- (major) §4.3 states snapshots `are sent unconditionally every tick at 60 Hz; the server rate-limits them to a minimum tick gap of 1 even when acks stall.` A minimum gap of 1 tick at 60 Hz IS every tick, so the 'rate-limits' clause either restates the previous clause or silently means something else (e.g. gap of ≥1 tick under backpressure). The actual backpressure policy is undefined.
 
 ## ambiguity
 
-- (major) §5.4 says "client sends `Pong(nonce)` every 500 ms; server replies" and §4.3 lists only `Pong` (0x09) — there is no `Ping` frame. In standard usage the initiator sends Ping and the responder sends Pong; here the client is sending Pong unsolicited. It is also unclear what the server replies *with* (another Pong? An Ack?) and which side's 3 s timeout the "no pong for 3 s" rule refers to. Add a `Ping` frame or rename, and state explicitly who measures what timeout.
-- (major) §5.3 states the server drains "up to 8 rows of garbage" before the next piece spawn, but does not say what happens to rows in excess of 8 in the queue. Do they persist to the next spawn, get coalesced, or get dropped? This is directly observable to players (it changes pressure dynamics after a quad combo) and must be pinned down.
-- (major) §2.5 caps match duration at 10 minutes "otherwise sudden-death", but sudden-death is never defined anywhere else in the spec. Which rules change (gravity speed-up, forced garbage, simultaneous top-out resolution, draw handling)? Without a definition neither the server sim nor the manual test plan can verify it.
-- (major) §5.1 and §9 rely on "fixed-point only" math to guarantee cross-arch determinism, but no section specifies which fields convert from float to fixed-point, what the scale/precision is, or how this interacts with the existing v0.1 simulation (which presumably uses floats for gravity, DAS, etc.). The determinism claim and the cross-arch CI test in §6.2 both rest on an unspecified conversion.
-- (major) Error/Goodbye enum values are referenced but not enumerated. §5.4 names `Goodbye(PeerDisconnected)` and `Goodbye(UserQuit)`; §6.1 names `Error(VersionMismatch)`; user story 2 implies discriminated errors for DNS/TLS/handshake/version-mismatch/room-not-found. §4.3 merely describes the frames as "reason (enum)" and "code, human-readable string" without listing the enum members. Add an authoritative enum table — this is wire-breaking once v1 ships.
-- (minor) §5.6 defines both `--server URL` and the `BLOCKTXT_SERVER` env var but does not specify precedence when both are set, nor what happens when the value is malformed (crash vs fall back to compiled-in default). CLI precedence rules should be unambiguous before shipping.
-- (minor) §5.6 shows `blocktxt mp join ABCDE` (uppercase) but §4.2 defines codes as Crockford-base32, which is conventionally case-insensitive on input. The spec does not say whether `abcde` is accepted, normalised, or rejected. Given user story 2 explicitly emphasises actionable errors for room-not-found, case handling must be pinned down.
-- (major) §5.3 seeds garbage-gap RNG from "match seed + tick + recipient id", but recipient id is not defined anywhere (is it host=0/guest=1? a UUID? the room code?). Two clients computing different recipient ids will produce divergent garbage and desync the determinism test in §6.2. Pin this down.
-- (minor) §2.3 states "No client-side prediction in v1" but §4.2 defines a `SnapshotMirror` that the render thread reads "each frame" with the net thread "one tick behind at worst". If the render frame rate is 60 fps and the network is lossy/jittery, the render loop will either block (stutter) or display a stale tick. The spec does not say which, nor what the mirror does when no new snapshot has arrived by frame time. This is visible to players.
+- (major) Garbage-exchange rules are underspecified. §5.3 gives `garbage_out = lines_cleared - 1` and a specific `B2B quad → 5` value; §6.1 adds a test for `B2B × 1.5 rounding`. Rounding mode (floor/ceil/banker's) is not stated; B2B doubles and triples are not specified; interaction with the `up to 8 rows` drain cap in §5.3 (does excess stay queued? drop?) is not stated; and §6.1's garbage-table test does not cover the cap or the B2B-double/triple cases.
+- (major) §2.5 specifies a 10-minute hard cap with `otherwise sudden-death`, but sudden-death mechanics are never defined anywhere in the spec — how the winner is determined (by score? by well height? coin flip?), whether garbage rate changes, or whether the cap terminates the match outright. A release-blocking rule with no defined behavior.
+- (minor) §5.4 says `client sends Pong(nonce) every 500 ms; server replies`, but §4.3's frame catalogue lists only `Pong (0x09)` with no `Ping`. Either the naming is inverted (clients should send `Ping`, server responds with `Pong`) or both sides emit `Pong`, which makes correlation ambiguous and inconsistent with RFC 6455 semantics.
+- (minor) §4.2 defines `sim::Match::step(inputs_a, inputs_b, dt) -> …` while §5.1 says `time advances only via step(dt) where dt is always exactly one tick on the server`. Exposing `dt` as a parameter while requiring it to be a constant invites determinism drift — if the client mirror ever passes a different `dt` (e.g. for catch-up), determinism breaks silently. Spec should either remove the parameter or state the permitted values and what happens otherwise.
+- (minor) §5.3's garbage RNG is described as `seeded from match seed + tick + recipient id, so deterministic`, but the mixing function is not defined. §5.1 separately says the simulation uses a single `ChaCha20Rng` seeded from the match seed. If the garbage RNG is a sub-stream of the sim RNG the call-order must be pinned; if it is an independent RNG the derivation function (e.g. `ChaCha20Rng::from_seed(hash(match_seed ∥ tick ∥ recipient))`) must be specified. Either way, two reasonable implementations can diverge.
+- (minor) §4.3's `Input` frame is described as `bitset of Inputs`, but the bit layout (which input maps to which bit) is not specified. For a versioned wire protocol where `Input` is replay-safe and cross-client, the bit assignment is load-bearing and should be pinned in the spec.
+- (minor) §4.3's `Hello` frame carries `capabilities`, but the set of legal capability tags and the negotiation algorithm (intersection? fail on unknown? required vs optional caps?) are not defined. Given §1's `Version mismatch → clean refusal` non-goal, the role of `capabilities` in v1 is unclear — is it forward-compatibility scaffolding, or does it gate behavior in v1?
+- (minor) §5.6 defines both `--server URL` and `BLOCKTXT_SERVER` env var, but precedence when both are set is not specified. Convention varies (CLI usually wins); a spec that names both should say which.
+- (minor) §5.3 HUD garbage indicator reuses existing `DIM → OVERLAY → NEW_BEST` colour ramp, but the pending-row thresholds at which each step triggers are not defined. Without thresholds, two implementations render different HUDs for identical state.
+- (minor) §2.3 promises `No client-side prediction in v1` with `server-authoritative fixed-tick`, and §4.2 describes `SnapshotMirror` as `One tick behind at worst`. The visible rendering policy is under-described: is the local player's own piece rendered from the server snapshot (perceived lag = RTT + 2 ticks) or from a local input-echo ghost? §5.2 state diagram doesn't resolve this, and the choice materially affects feel on the stated ≤150 ms budget.
 
 ## weak-testing
 
-- (major) §6.1 tick-budget invariant tests only 2 active matches, but §2.5 targets 200 concurrent matches per 1 vCPU. A 2-match microbench tells you almost nothing about whether the 200-match scale target holds (scheduler overhead, allocator pressure, and cache behaviour all change non-linearly). Add a soak or load test that exercises a realistic match count, or explicitly lower the advertised scale target.
-- (major) The §2.5 bandwidth budget (≤ 8 KiB/s steady state per client, delta-compressed snapshots) has no corresponding test. Given delta-compression is claimed as the mechanism that makes the budget achievable, this is load-bearing and should be asserted in an integration test that measures bytes-on-wire over a scripted match.
-- (major) §5.5 promises the server "validates every client `Input` against the simulation" and §5.5 also promises rate limiting on `JoinRoom` (10/min/IP), but §6 contains no tests for either: no adversarial-input test (malformed bitsets, inputs from the wrong player slot, inputs for a match that ended), and no rate-limit test. For a publicly-exposed service these are the tests you actually need.
-- (major) §6.2 "Loopback match: … script a 30-second match" does not say what the scripted inputs are or what invariants the assertion checks beyond "`MatchResult` event is emitted and both clients exit cleanly". Without a deterministic input script and explicit output expectations (final scores, winner identity, garbage totals) the test is unlikely to catch regressions.
-- (major) Heartbeat/stall detection (§5.4: "No pong for 3 s → server declares the session stalled and awards the match to the peer") is one of the most subtle pieces of the protocol and has no unit test. §6.2 has a "kill one client's socket" test, but TCP-reset is not the same code path as a silent stall (no RST, just packet loss). Add a test that simulates dropped packets/zero bandwidth without closing the socket.
-- (minor) §6.1 version-mismatch test only exercises the client-newer-than-server direction (`proto_version = 2` against v1). The reverse (old client against new server) is the common rollout failure and is not tested. Add a symmetric test.
-- (minor) Client-side snapshot-mirror correctness (SPSC slot, "one tick behind at worst") is called out as a key abstraction in §4.2 but has no test in §6. If the mirror tears or goes stale the render layer silently shows wrong state; this is exactly the kind of concurrency code that needs a targeted unit test with a stressing harness.
+- (major) The tests plan has no coverage for the snapshot pipeline itself: no test for delta-snapshot encoding/decoding correctness, no test for recovery when `ack_seq` falls behind beyond a one-tick window, no test for the `INPUT_DELAY = 2 ticks` pipeline (e.g. that an input pressed at client tick T is applied at server tick T+2 under nominal RTT), and no test for the 3-second heartbeat-stall → auto-award rule in §5.4. These are the core correctness properties of the chosen sync model.
+- (major) §2.5 commits to concrete performance budgets: `≤ 8 KiB/s` steady-state client bandwidth and `200 concurrent matches per 1-vCPU / 512 MiB` server. §6.1's only performance test is a criterion bench of `server step for 2 active matches < 1 ms`. There is no bandwidth measurement and no load test at or near the 200-match target, so both headline numbers are unverified claims.
+- (minor) Security-posture rules in §5.5 have thin automated coverage. `≤ 10 JoinRoom attempts per IP per minute` rate-limit, `silently dropped` invalid-input rule, and `7-day log retention` are all asserted but have no test (automated or manual) in §6. The fuzz target on `proto::decode` partially covers crash-resistance but not validation/rate limiting.
+- (minor) §6.1 cross-arch determinism lists macOS arm64 and Linux x86_64, but §8 Sprint 4 QA matrix adds macOS x86_64, and §6.3 CI additions do not include it. The determinism SHA-256 digest check as specified does not cover the platform QA is expected to sign off on.
+- (minor) `Ctrl-C / SIGTERM sends Goodbye(UserQuit) before closing the socket` (§5.4) is only exercised by a manual checklist item in §6.4. A signal-driven graceful-shutdown path is easy to regress silently; an automated test spawning the binary and sending SIGTERM would be cheap and is missing.
 
 ## missing-requirement
 
-- (major) §9 risk table mentions "Fixed-point only" as the desync mitigation, but §5 Implementation details contains no subsection specifying the fixed-point representation, arithmetic rules, or conversion strategy from the existing v0.1 float-based simulation. Either add a §5.x "Deterministic arithmetic" subsection or drop the fixed-point commitment.
+- (minor) Mandatory baseline check: all nine sections are present in the document (version header `SPEC v0.1`; §1 goal/why; §3 five user stories with persona+action+outcome; §4 architecture — though see the `architecture not yet specified` contradiction above; §5 implementation details; §6 tests plan with red/green TDD call-out in §6.1; §7 team with counts and skill labels totalling 4 FT + 1 split; §8 4-sprint plan with explicit `→`/`∥` parallelization; §10 changelog). No missing-section finding is raised; this entry is informational.
 
 ## suggested-next-version
 
@@ -46,111 +44,101 @@ v0.2
   "findings": [
     {
       "category": "contradiction",
-      "text": "§4 Architecture contains a placeholder block between `architecture:begin` and `architecture:end` that reads \"(architecture not yet specified)\" yet §4.1–4.3 provide a detailed architecture (component diagram, key abstractions, wire protocol). A mechanical reader (or template tool) honouring the marker block would conclude the architecture section is empty/unfilled. Either populate the marker block with the diagram from §4.1 or delete the placeholder; as written the two statements directly contradict each other.",
+      "text": "§4 contains an architecture placeholder block that literally reads `(architecture not yet specified)` between the `<!-- architecture:begin -->` and `<!-- architecture:end -->` markers, directly contradicting the detailed content in §§4.1–4.3. Either the placeholder must be removed or the real diagram moved inside the block; as written, an automated doc-generator reading only the marked region will emit `architecture not yet specified` for a spec that does in fact specify architecture.",
       "severity": "major"
     },
     {
       "category": "contradiction",
-      "text": "§8 Sprint 1 states the `multiplayer` feature flag is \"defaulted *off* until Sprint 3 so main stays shippable\", yet Sprint 2 ships `blocktxt mp local` as a user-facing dev aid. `mp local` lives inside the multiplayer subcommand tree and cannot ship in Sprint 2 if the flag only turns on in Sprint 3. Resolve by either flipping the flag in Sprint 2 or gating `mp local` behind a separate flag.",
+      "text": "§2.5 table row reads: `| RTT budget | ≤ 150 ms one-way latency for \"feels responsive\" |`. RTT (round-trip time) and one-way latency are different quantities; the budget can be one or the other but not both. This is load-bearing for §2.3's claim that RTT + 2-tick input delay is imperceptible — if the real target is 150 ms one-way (i.e. 300 ms RTT) the perceptibility claim is wrong.",
       "severity": "major"
     },
     {
       "category": "contradiction",
-      "text": "§2.5 scale table labels the 150 ms budget as both RTT and one-way latency in the same row: `RTT budget | ≤ 150 ms one-way latency for \"feels responsive\"`. RTT (round-trip) and one-way are factor-of-2 different; the protocol's 2-tick input-delay argument in §2.3 only checks out under one interpretation. Pick one definition and use it consistently (the downstream heartbeat, input-delay, and manual-test thresholds all depend on it).",
-      "severity": "major"
-    },
-    {
-      "category": "contradiction",
-      "text": "§5.3 specifies garbage via formula `garbage_out = lines_cleared - 1` plus a single carve-out \"B2B quads send 5\", but §6.1 requires a test that `lines_cleared → garbage_out` matches \"the specified table exactly, including B2B × 1.5 rounding\". No such table and no ×1.5 rule appear anywhere in the spec. The test cannot be written against the current text; either add the full table (including B2B behaviour for triples/doubles and the ×1.5 rounding rule) or rewrite §6.1 to match the simple formula.",
+      "text": "§4.3 states snapshots `are sent unconditionally every tick at 60 Hz; the server rate-limits them to a minimum tick gap of 1 even when acks stall.` A minimum gap of 1 tick at 60 Hz IS every tick, so the 'rate-limits' clause either restates the previous clause or silently means something else (e.g. gap of ≥1 tick under backpressure). The actual backpressure policy is undefined.",
       "severity": "major"
     },
     {
       "category": "ambiguity",
-      "text": "§5.4 says \"client sends `Pong(nonce)` every 500 ms; server replies\" and §4.3 lists only `Pong` (0x09) — there is no `Ping` frame. In standard usage the initiator sends Ping and the responder sends Pong; here the client is sending Pong unsolicited. It is also unclear what the server replies *with* (another Pong? An Ack?) and which side's 3 s timeout the \"no pong for 3 s\" rule refers to. Add a `Ping` frame or rename, and state explicitly who measures what timeout.",
+      "text": "Garbage-exchange rules are underspecified. §5.3 gives `garbage_out = lines_cleared - 1` and a specific `B2B quad → 5` value; §6.1 adds a test for `B2B × 1.5 rounding`. Rounding mode (floor/ceil/banker's) is not stated; B2B doubles and triples are not specified; interaction with the `up to 8 rows` drain cap in §5.3 (does excess stay queued? drop?) is not stated; and §6.1's garbage-table test does not cover the cap or the B2B-double/triple cases.",
       "severity": "major"
     },
     {
       "category": "ambiguity",
-      "text": "§5.3 states the server drains \"up to 8 rows of garbage\" before the next piece spawn, but does not say what happens to rows in excess of 8 in the queue. Do they persist to the next spawn, get coalesced, or get dropped? This is directly observable to players (it changes pressure dynamics after a quad combo) and must be pinned down.",
+      "text": "§2.5 specifies a 10-minute hard cap with `otherwise sudden-death`, but sudden-death mechanics are never defined anywhere in the spec — how the winner is determined (by score? by well height? coin flip?), whether garbage rate changes, or whether the cap terminates the match outright. A release-blocking rule with no defined behavior.",
+      "severity": "major"
+    },
+    {
+      "category": "weak-testing",
+      "text": "The tests plan has no coverage for the snapshot pipeline itself: no test for delta-snapshot encoding/decoding correctness, no test for recovery when `ack_seq` falls behind beyond a one-tick window, no test for the `INPUT_DELAY = 2 ticks` pipeline (e.g. that an input pressed at client tick T is applied at server tick T+2 under nominal RTT), and no test for the 3-second heartbeat-stall → auto-award rule in §5.4. These are the core correctness properties of the chosen sync model.",
+      "severity": "major"
+    },
+    {
+      "category": "weak-testing",
+      "text": "§2.5 commits to concrete performance budgets: `≤ 8 KiB/s` steady-state client bandwidth and `200 concurrent matches per 1-vCPU / 512 MiB` server. §6.1's only performance test is a criterion bench of `server step for 2 active matches < 1 ms`. There is no bandwidth measurement and no load test at or near the 200-match target, so both headline numbers are unverified claims.",
       "severity": "major"
     },
     {
       "category": "ambiguity",
-      "text": "§2.5 caps match duration at 10 minutes \"otherwise sudden-death\", but sudden-death is never defined anywhere else in the spec. Which rules change (gravity speed-up, forced garbage, simultaneous top-out resolution, draw handling)? Without a definition neither the server sim nor the manual test plan can verify it.",
-      "severity": "major"
-    },
-    {
-      "category": "ambiguity",
-      "text": "§5.1 and §9 rely on \"fixed-point only\" math to guarantee cross-arch determinism, but no section specifies which fields convert from float to fixed-point, what the scale/precision is, or how this interacts with the existing v0.1 simulation (which presumably uses floats for gravity, DAS, etc.). The determinism claim and the cross-arch CI test in §6.2 both rest on an unspecified conversion.",
-      "severity": "major"
-    },
-    {
-      "category": "ambiguity",
-      "text": "Error/Goodbye enum values are referenced but not enumerated. §5.4 names `Goodbye(PeerDisconnected)` and `Goodbye(UserQuit)`; §6.1 names `Error(VersionMismatch)`; user story 2 implies discriminated errors for DNS/TLS/handshake/version-mismatch/room-not-found. §4.3 merely describes the frames as \"reason (enum)\" and \"code, human-readable string\" without listing the enum members. Add an authoritative enum table — this is wire-breaking once v1 ships.",
-      "severity": "major"
-    },
-    {
-      "category": "ambiguity",
-      "text": "§5.6 defines both `--server URL` and the `BLOCKTXT_SERVER` env var but does not specify precedence when both are set, nor what happens when the value is malformed (crash vs fall back to compiled-in default). CLI precedence rules should be unambiguous before shipping.",
+      "text": "§5.4 says `client sends Pong(nonce) every 500 ms; server replies`, but §4.3's frame catalogue lists only `Pong (0x09)` with no `Ping`. Either the naming is inverted (clients should send `Ping`, server responds with `Pong`) or both sides emit `Pong`, which makes correlation ambiguous and inconsistent with RFC 6455 semantics.",
       "severity": "minor"
     },
     {
       "category": "ambiguity",
-      "text": "§5.6 shows `blocktxt mp join ABCDE` (uppercase) but §4.2 defines codes as Crockford-base32, which is conventionally case-insensitive on input. The spec does not say whether `abcde` is accepted, normalised, or rejected. Given user story 2 explicitly emphasises actionable errors for room-not-found, case handling must be pinned down.",
-      "severity": "minor"
-    },
-    {
-      "category": "weak-testing",
-      "text": "§6.1 tick-budget invariant tests only 2 active matches, but §2.5 targets 200 concurrent matches per 1 vCPU. A 2-match microbench tells you almost nothing about whether the 200-match scale target holds (scheduler overhead, allocator pressure, and cache behaviour all change non-linearly). Add a soak or load test that exercises a realistic match count, or explicitly lower the advertised scale target.",
-      "severity": "major"
-    },
-    {
-      "category": "weak-testing",
-      "text": "The §2.5 bandwidth budget (≤ 8 KiB/s steady state per client, delta-compressed snapshots) has no corresponding test. Given delta-compression is claimed as the mechanism that makes the budget achievable, this is load-bearing and should be asserted in an integration test that measures bytes-on-wire over a scripted match.",
-      "severity": "major"
-    },
-    {
-      "category": "weak-testing",
-      "text": "§5.5 promises the server \"validates every client `Input` against the simulation\" and §5.5 also promises rate limiting on `JoinRoom` (10/min/IP), but §6 contains no tests for either: no adversarial-input test (malformed bitsets, inputs from the wrong player slot, inputs for a match that ended), and no rate-limit test. For a publicly-exposed service these are the tests you actually need.",
-      "severity": "major"
-    },
-    {
-      "category": "weak-testing",
-      "text": "§6.2 \"Loopback match: … script a 30-second match\" does not say what the scripted inputs are or what invariants the assertion checks beyond \"`MatchResult` event is emitted and both clients exit cleanly\". Without a deterministic input script and explicit output expectations (final scores, winner identity, garbage totals) the test is unlikely to catch regressions.",
-      "severity": "major"
-    },
-    {
-      "category": "weak-testing",
-      "text": "Heartbeat/stall detection (§5.4: \"No pong for 3 s → server declares the session stalled and awards the match to the peer\") is one of the most subtle pieces of the protocol and has no unit test. §6.2 has a \"kill one client's socket\" test, but TCP-reset is not the same code path as a silent stall (no RST, just packet loss). Add a test that simulates dropped packets/zero bandwidth without closing the socket.",
-      "severity": "major"
-    },
-    {
-      "category": "weak-testing",
-      "text": "§6.1 version-mismatch test only exercises the client-newer-than-server direction (`proto_version = 2` against v1). The reverse (old client against new server) is the common rollout failure and is not tested. Add a symmetric test.",
-      "severity": "minor"
-    },
-    {
-      "category": "weak-testing",
-      "text": "Client-side snapshot-mirror correctness (SPSC slot, \"one tick behind at worst\") is called out as a key abstraction in §4.2 but has no test in §6. If the mirror tears or goes stale the render layer silently shows wrong state; this is exactly the kind of concurrency code that needs a targeted unit test with a stressing harness.",
+      "text": "§4.2 defines `sim::Match::step(inputs_a, inputs_b, dt) -> …` while §5.1 says `time advances only via step(dt) where dt is always exactly one tick on the server`. Exposing `dt` as a parameter while requiring it to be a constant invites determinism drift — if the client mirror ever passes a different `dt` (e.g. for catch-up), determinism breaks silently. Spec should either remove the parameter or state the permitted values and what happens otherwise.",
       "severity": "minor"
     },
     {
       "category": "ambiguity",
-      "text": "§5.3 seeds garbage-gap RNG from \"match seed + tick + recipient id\", but recipient id is not defined anywhere (is it host=0/guest=1? a UUID? the room code?). Two clients computing different recipient ids will produce divergent garbage and desync the determinism test in §6.2. Pin this down.",
-      "severity": "major"
+      "text": "§5.3's garbage RNG is described as `seeded from match seed + tick + recipient id, so deterministic`, but the mixing function is not defined. §5.1 separately says the simulation uses a single `ChaCha20Rng` seeded from the match seed. If the garbage RNG is a sub-stream of the sim RNG the call-order must be pinned; if it is an independent RNG the derivation function (e.g. `ChaCha20Rng::from_seed(hash(match_seed ∥ tick ∥ recipient))`) must be specified. Either way, two reasonable implementations can diverge.",
+      "severity": "minor"
     },
     {
       "category": "ambiguity",
-      "text": "§2.3 states \"No client-side prediction in v1\" but §4.2 defines a `SnapshotMirror` that the render thread reads \"each frame\" with the net thread \"one tick behind at worst\". If the render frame rate is 60 fps and the network is lossy/jittery, the render loop will either block (stutter) or display a stale tick. The spec does not say which, nor what the mirror does when no new snapshot has arrived by frame time. This is visible to players.",
+      "text": "§4.3's `Input` frame is described as `bitset of Inputs`, but the bit layout (which input maps to which bit) is not specified. For a versioned wire protocol where `Input` is replay-safe and cross-client, the bit assignment is load-bearing and should be pinned in the spec.",
+      "severity": "minor"
+    },
+    {
+      "category": "ambiguity",
+      "text": "§4.3's `Hello` frame carries `capabilities`, but the set of legal capability tags and the negotiation algorithm (intersection? fail on unknown? required vs optional caps?) are not defined. Given §1's `Version mismatch → clean refusal` non-goal, the role of `capabilities` in v1 is unclear — is it forward-compatibility scaffolding, or does it gate behavior in v1?",
+      "severity": "minor"
+    },
+    {
+      "category": "ambiguity",
+      "text": "§5.6 defines both `--server URL` and `BLOCKTXT_SERVER` env var, but precedence when both are set is not specified. Convention varies (CLI usually wins); a spec that names both should say which.",
+      "severity": "minor"
+    },
+    {
+      "category": "ambiguity",
+      "text": "§5.3 HUD garbage indicator reuses existing `DIM → OVERLAY → NEW_BEST` colour ramp, but the pending-row thresholds at which each step triggers are not defined. Without thresholds, two implementations render different HUDs for identical state.",
+      "severity": "minor"
+    },
+    {
+      "category": "weak-testing",
+      "text": "Security-posture rules in §5.5 have thin automated coverage. `≤ 10 JoinRoom attempts per IP per minute` rate-limit, `silently dropped` invalid-input rule, and `7-day log retention` are all asserted but have no test (automated or manual) in §6. The fuzz target on `proto::decode` partially covers crash-resistance but not validation/rate limiting.",
+      "severity": "minor"
+    },
+    {
+      "category": "weak-testing",
+      "text": "§6.1 cross-arch determinism lists macOS arm64 and Linux x86_64, but §8 Sprint 4 QA matrix adds macOS x86_64, and §6.3 CI additions do not include it. The determinism SHA-256 digest check as specified does not cover the platform QA is expected to sign off on.",
+      "severity": "minor"
+    },
+    {
+      "category": "weak-testing",
+      "text": "`Ctrl-C / SIGTERM sends Goodbye(UserQuit) before closing the socket` (§5.4) is only exercised by a manual checklist item in §6.4. A signal-driven graceful-shutdown path is easy to regress silently; an automated test spawning the binary and sending SIGTERM would be cheap and is missing.",
+      "severity": "minor"
+    },
+    {
+      "category": "ambiguity",
+      "text": "§2.3 promises `No client-side prediction in v1` with `server-authoritative fixed-tick`, and §4.2 describes `SnapshotMirror` as `One tick behind at worst`. The visible rendering policy is under-described: is the local player's own piece rendered from the server snapshot (perceived lag = RTT + 2 ticks) or from a local input-echo ghost? §5.2 state diagram doesn't resolve this, and the choice materially affects feel on the stated ≤150 ms budget.",
       "severity": "minor"
     },
     {
       "category": "missing-requirement",
-      "text": "§9 risk table mentions \"Fixed-point only\" as the desync mitigation, but §5 Implementation details contains no subsection specifying the fixed-point representation, arithmetic rules, or conversion strategy from the existing v0.1 float-based simulation. Either add a §5.x \"Deterministic arithmetic\" subsection or drop the fixed-point commitment.",
-      "severity": "major"
+      "text": "Mandatory baseline check: all nine sections are present in the document (version header `SPEC v0.1`; §1 goal/why; §3 five user stories with persona+action+outcome; §4 architecture — though see the `architecture not yet specified` contradiction above; §5 implementation details; §6 tests plan with red/green TDD call-out in §6.1; §7 team with counts and skill labels totalling 4 FT + 1 split; §8 4-sprint plan with explicit `→`/`∥` parallelization; §10 changelog). No missing-section finding is raised; this entry is informational.",
+      "severity": "minor"
     }
   ],
-  "summary": "The spec covers all nine mandatory baseline sections and is strong on scope discipline, topology rationale, and sprint parallelisation. The most serious gaps are: (1) the §4 architecture placeholder contradicts the populated §4.1–4.3; (2) the Sprint-1 feature-flag rule contradicts Sprint 2 shipping `mp local`; (3) garbage-exchange prose (§5.3) does not match the B2B ×1.5 table referenced by its test (§6.1); (4) RTT-vs-one-way conflated in §2.5; (5) heartbeat uses `Pong` with no `Ping` frame defined. Multiple enums (Goodbye/Error reasons), the fixed-point arithmetic scheme, sudden-death rules, and garbage queue-overflow behaviour are referenced but never specified. Testing is weak on the load-bearing claims: bandwidth budget, 200-match scale target, adversarial input validation, rate limiting, and silent-stall heartbeat timeout all lack corresponding tests. No idea-contradiction findings — the original idea contains no explicit `NOT X` disclaimers to violate.",
+  "summary": "Strong first draft: all nine mandatory sections are present, the non-goals are unusually disciplined, and the TDD-first test list exists. The main weaknesses are (a) a broken architecture placeholder that contradicts the real content, (b) a confused RTT-vs-one-way budget in §2.5 that undermines the sync-model justification, (c) underspecified garbage/B2B rules and undefined sudden-death behavior at the 10-minute cap, (d) missing automated coverage for the snapshot-delta pipeline, input-delay behavior, heartbeat stall-timeout, bandwidth, and 200-match concurrency claims, and (e) a set of smaller wire-protocol ambiguities (Ping vs Pong, Input bit layout, capabilities negotiation, delta encoding, garbage-RNG derivation) that must be pinned before a versioned v1 protocol can claim cross-implementation compatibility.",
   "suggested_next_version": "v0.2",
   "usage": null,
   "effort_used": "max"

--- a/.samo/spec/multiplayer-v1/reviews/r01/claude.md
+++ b/.samo/spec/multiplayer-v1/reviews/r01/claude.md
@@ -1,0 +1,158 @@
+# Reviewer B — Claude
+
+## summary
+
+The spec covers all nine mandatory baseline sections and is strong on scope discipline, topology rationale, and sprint parallelisation. The most serious gaps are: (1) the §4 architecture placeholder contradicts the populated §4.1–4.3; (2) the Sprint-1 feature-flag rule contradicts Sprint 2 shipping `mp local`; (3) garbage-exchange prose (§5.3) does not match the B2B ×1.5 table referenced by its test (§6.1); (4) RTT-vs-one-way conflated in §2.5; (5) heartbeat uses `Pong` with no `Ping` frame defined. Multiple enums (Goodbye/Error reasons), the fixed-point arithmetic scheme, sudden-death rules, and garbage queue-overflow behaviour are referenced but never specified. Testing is weak on the load-bearing claims: bandwidth budget, 200-match scale target, adversarial input validation, rate limiting, and silent-stall heartbeat timeout all lack corresponding tests. No idea-contradiction findings — the original idea contains no explicit `NOT X` disclaimers to violate.
+
+## contradiction
+
+- (major) §4 Architecture contains a placeholder block between `architecture:begin` and `architecture:end` that reads "(architecture not yet specified)" yet §4.1–4.3 provide a detailed architecture (component diagram, key abstractions, wire protocol). A mechanical reader (or template tool) honouring the marker block would conclude the architecture section is empty/unfilled. Either populate the marker block with the diagram from §4.1 or delete the placeholder; as written the two statements directly contradict each other.
+- (major) §8 Sprint 1 states the `multiplayer` feature flag is "defaulted *off* until Sprint 3 so main stays shippable", yet Sprint 2 ships `blocktxt mp local` as a user-facing dev aid. `mp local` lives inside the multiplayer subcommand tree and cannot ship in Sprint 2 if the flag only turns on in Sprint 3. Resolve by either flipping the flag in Sprint 2 or gating `mp local` behind a separate flag.
+- (major) §2.5 scale table labels the 150 ms budget as both RTT and one-way latency in the same row: `RTT budget | ≤ 150 ms one-way latency for "feels responsive"`. RTT (round-trip) and one-way are factor-of-2 different; the protocol's 2-tick input-delay argument in §2.3 only checks out under one interpretation. Pick one definition and use it consistently (the downstream heartbeat, input-delay, and manual-test thresholds all depend on it).
+- (major) §5.3 specifies garbage via formula `garbage_out = lines_cleared - 1` plus a single carve-out "B2B quads send 5", but §6.1 requires a test that `lines_cleared → garbage_out` matches "the specified table exactly, including B2B × 1.5 rounding". No such table and no ×1.5 rule appear anywhere in the spec. The test cannot be written against the current text; either add the full table (including B2B behaviour for triples/doubles and the ×1.5 rounding rule) or rewrite §6.1 to match the simple formula.
+
+## ambiguity
+
+- (major) §5.4 says "client sends `Pong(nonce)` every 500 ms; server replies" and §4.3 lists only `Pong` (0x09) — there is no `Ping` frame. In standard usage the initiator sends Ping and the responder sends Pong; here the client is sending Pong unsolicited. It is also unclear what the server replies *with* (another Pong? An Ack?) and which side's 3 s timeout the "no pong for 3 s" rule refers to. Add a `Ping` frame or rename, and state explicitly who measures what timeout.
+- (major) §5.3 states the server drains "up to 8 rows of garbage" before the next piece spawn, but does not say what happens to rows in excess of 8 in the queue. Do they persist to the next spawn, get coalesced, or get dropped? This is directly observable to players (it changes pressure dynamics after a quad combo) and must be pinned down.
+- (major) §2.5 caps match duration at 10 minutes "otherwise sudden-death", but sudden-death is never defined anywhere else in the spec. Which rules change (gravity speed-up, forced garbage, simultaneous top-out resolution, draw handling)? Without a definition neither the server sim nor the manual test plan can verify it.
+- (major) §5.1 and §9 rely on "fixed-point only" math to guarantee cross-arch determinism, but no section specifies which fields convert from float to fixed-point, what the scale/precision is, or how this interacts with the existing v0.1 simulation (which presumably uses floats for gravity, DAS, etc.). The determinism claim and the cross-arch CI test in §6.2 both rest on an unspecified conversion.
+- (major) Error/Goodbye enum values are referenced but not enumerated. §5.4 names `Goodbye(PeerDisconnected)` and `Goodbye(UserQuit)`; §6.1 names `Error(VersionMismatch)`; user story 2 implies discriminated errors for DNS/TLS/handshake/version-mismatch/room-not-found. §4.3 merely describes the frames as "reason (enum)" and "code, human-readable string" without listing the enum members. Add an authoritative enum table — this is wire-breaking once v1 ships.
+- (minor) §5.6 defines both `--server URL` and the `BLOCKTXT_SERVER` env var but does not specify precedence when both are set, nor what happens when the value is malformed (crash vs fall back to compiled-in default). CLI precedence rules should be unambiguous before shipping.
+- (minor) §5.6 shows `blocktxt mp join ABCDE` (uppercase) but §4.2 defines codes as Crockford-base32, which is conventionally case-insensitive on input. The spec does not say whether `abcde` is accepted, normalised, or rejected. Given user story 2 explicitly emphasises actionable errors for room-not-found, case handling must be pinned down.
+- (major) §5.3 seeds garbage-gap RNG from "match seed + tick + recipient id", but recipient id is not defined anywhere (is it host=0/guest=1? a UUID? the room code?). Two clients computing different recipient ids will produce divergent garbage and desync the determinism test in §6.2. Pin this down.
+- (minor) §2.3 states "No client-side prediction in v1" but §4.2 defines a `SnapshotMirror` that the render thread reads "each frame" with the net thread "one tick behind at worst". If the render frame rate is 60 fps and the network is lossy/jittery, the render loop will either block (stutter) or display a stale tick. The spec does not say which, nor what the mirror does when no new snapshot has arrived by frame time. This is visible to players.
+
+## weak-testing
+
+- (major) §6.1 tick-budget invariant tests only 2 active matches, but §2.5 targets 200 concurrent matches per 1 vCPU. A 2-match microbench tells you almost nothing about whether the 200-match scale target holds (scheduler overhead, allocator pressure, and cache behaviour all change non-linearly). Add a soak or load test that exercises a realistic match count, or explicitly lower the advertised scale target.
+- (major) The §2.5 bandwidth budget (≤ 8 KiB/s steady state per client, delta-compressed snapshots) has no corresponding test. Given delta-compression is claimed as the mechanism that makes the budget achievable, this is load-bearing and should be asserted in an integration test that measures bytes-on-wire over a scripted match.
+- (major) §5.5 promises the server "validates every client `Input` against the simulation" and §5.5 also promises rate limiting on `JoinRoom` (10/min/IP), but §6 contains no tests for either: no adversarial-input test (malformed bitsets, inputs from the wrong player slot, inputs for a match that ended), and no rate-limit test. For a publicly-exposed service these are the tests you actually need.
+- (major) §6.2 "Loopback match: … script a 30-second match" does not say what the scripted inputs are or what invariants the assertion checks beyond "`MatchResult` event is emitted and both clients exit cleanly". Without a deterministic input script and explicit output expectations (final scores, winner identity, garbage totals) the test is unlikely to catch regressions.
+- (major) Heartbeat/stall detection (§5.4: "No pong for 3 s → server declares the session stalled and awards the match to the peer") is one of the most subtle pieces of the protocol and has no unit test. §6.2 has a "kill one client's socket" test, but TCP-reset is not the same code path as a silent stall (no RST, just packet loss). Add a test that simulates dropped packets/zero bandwidth without closing the socket.
+- (minor) §6.1 version-mismatch test only exercises the client-newer-than-server direction (`proto_version = 2` against v1). The reverse (old client against new server) is the common rollout failure and is not tested. Add a symmetric test.
+- (minor) Client-side snapshot-mirror correctness (SPSC slot, "one tick behind at worst") is called out as a key abstraction in §4.2 but has no test in §6. If the mirror tears or goes stale the render layer silently shows wrong state; this is exactly the kind of concurrency code that needs a targeted unit test with a stressing harness.
+
+## missing-requirement
+
+- (major) §9 risk table mentions "Fixed-point only" as the desync mitigation, but §5 Implementation details contains no subsection specifying the fixed-point representation, arithmetic rules, or conversion strategy from the existing v0.1 float-based simulation. Either add a §5.x "Deterministic arithmetic" subsection or drop the fixed-point commitment.
+
+## suggested-next-version
+
+v0.2
+
+<!-- samospec:critique v1 -->
+{
+  "findings": [
+    {
+      "category": "contradiction",
+      "text": "§4 Architecture contains a placeholder block between `architecture:begin` and `architecture:end` that reads \"(architecture not yet specified)\" yet §4.1–4.3 provide a detailed architecture (component diagram, key abstractions, wire protocol). A mechanical reader (or template tool) honouring the marker block would conclude the architecture section is empty/unfilled. Either populate the marker block with the diagram from §4.1 or delete the placeholder; as written the two statements directly contradict each other.",
+      "severity": "major"
+    },
+    {
+      "category": "contradiction",
+      "text": "§8 Sprint 1 states the `multiplayer` feature flag is \"defaulted *off* until Sprint 3 so main stays shippable\", yet Sprint 2 ships `blocktxt mp local` as a user-facing dev aid. `mp local` lives inside the multiplayer subcommand tree and cannot ship in Sprint 2 if the flag only turns on in Sprint 3. Resolve by either flipping the flag in Sprint 2 or gating `mp local` behind a separate flag.",
+      "severity": "major"
+    },
+    {
+      "category": "contradiction",
+      "text": "§2.5 scale table labels the 150 ms budget as both RTT and one-way latency in the same row: `RTT budget | ≤ 150 ms one-way latency for \"feels responsive\"`. RTT (round-trip) and one-way are factor-of-2 different; the protocol's 2-tick input-delay argument in §2.3 only checks out under one interpretation. Pick one definition and use it consistently (the downstream heartbeat, input-delay, and manual-test thresholds all depend on it).",
+      "severity": "major"
+    },
+    {
+      "category": "contradiction",
+      "text": "§5.3 specifies garbage via formula `garbage_out = lines_cleared - 1` plus a single carve-out \"B2B quads send 5\", but §6.1 requires a test that `lines_cleared → garbage_out` matches \"the specified table exactly, including B2B × 1.5 rounding\". No such table and no ×1.5 rule appear anywhere in the spec. The test cannot be written against the current text; either add the full table (including B2B behaviour for triples/doubles and the ×1.5 rounding rule) or rewrite §6.1 to match the simple formula.",
+      "severity": "major"
+    },
+    {
+      "category": "ambiguity",
+      "text": "§5.4 says \"client sends `Pong(nonce)` every 500 ms; server replies\" and §4.3 lists only `Pong` (0x09) — there is no `Ping` frame. In standard usage the initiator sends Ping and the responder sends Pong; here the client is sending Pong unsolicited. It is also unclear what the server replies *with* (another Pong? An Ack?) and which side's 3 s timeout the \"no pong for 3 s\" rule refers to. Add a `Ping` frame or rename, and state explicitly who measures what timeout.",
+      "severity": "major"
+    },
+    {
+      "category": "ambiguity",
+      "text": "§5.3 states the server drains \"up to 8 rows of garbage\" before the next piece spawn, but does not say what happens to rows in excess of 8 in the queue. Do they persist to the next spawn, get coalesced, or get dropped? This is directly observable to players (it changes pressure dynamics after a quad combo) and must be pinned down.",
+      "severity": "major"
+    },
+    {
+      "category": "ambiguity",
+      "text": "§2.5 caps match duration at 10 minutes \"otherwise sudden-death\", but sudden-death is never defined anywhere else in the spec. Which rules change (gravity speed-up, forced garbage, simultaneous top-out resolution, draw handling)? Without a definition neither the server sim nor the manual test plan can verify it.",
+      "severity": "major"
+    },
+    {
+      "category": "ambiguity",
+      "text": "§5.1 and §9 rely on \"fixed-point only\" math to guarantee cross-arch determinism, but no section specifies which fields convert from float to fixed-point, what the scale/precision is, or how this interacts with the existing v0.1 simulation (which presumably uses floats for gravity, DAS, etc.). The determinism claim and the cross-arch CI test in §6.2 both rest on an unspecified conversion.",
+      "severity": "major"
+    },
+    {
+      "category": "ambiguity",
+      "text": "Error/Goodbye enum values are referenced but not enumerated. §5.4 names `Goodbye(PeerDisconnected)` and `Goodbye(UserQuit)`; §6.1 names `Error(VersionMismatch)`; user story 2 implies discriminated errors for DNS/TLS/handshake/version-mismatch/room-not-found. §4.3 merely describes the frames as \"reason (enum)\" and \"code, human-readable string\" without listing the enum members. Add an authoritative enum table — this is wire-breaking once v1 ships.",
+      "severity": "major"
+    },
+    {
+      "category": "ambiguity",
+      "text": "§5.6 defines both `--server URL` and the `BLOCKTXT_SERVER` env var but does not specify precedence when both are set, nor what happens when the value is malformed (crash vs fall back to compiled-in default). CLI precedence rules should be unambiguous before shipping.",
+      "severity": "minor"
+    },
+    {
+      "category": "ambiguity",
+      "text": "§5.6 shows `blocktxt mp join ABCDE` (uppercase) but §4.2 defines codes as Crockford-base32, which is conventionally case-insensitive on input. The spec does not say whether `abcde` is accepted, normalised, or rejected. Given user story 2 explicitly emphasises actionable errors for room-not-found, case handling must be pinned down.",
+      "severity": "minor"
+    },
+    {
+      "category": "weak-testing",
+      "text": "§6.1 tick-budget invariant tests only 2 active matches, but §2.5 targets 200 concurrent matches per 1 vCPU. A 2-match microbench tells you almost nothing about whether the 200-match scale target holds (scheduler overhead, allocator pressure, and cache behaviour all change non-linearly). Add a soak or load test that exercises a realistic match count, or explicitly lower the advertised scale target.",
+      "severity": "major"
+    },
+    {
+      "category": "weak-testing",
+      "text": "The §2.5 bandwidth budget (≤ 8 KiB/s steady state per client, delta-compressed snapshots) has no corresponding test. Given delta-compression is claimed as the mechanism that makes the budget achievable, this is load-bearing and should be asserted in an integration test that measures bytes-on-wire over a scripted match.",
+      "severity": "major"
+    },
+    {
+      "category": "weak-testing",
+      "text": "§5.5 promises the server \"validates every client `Input` against the simulation\" and §5.5 also promises rate limiting on `JoinRoom` (10/min/IP), but §6 contains no tests for either: no adversarial-input test (malformed bitsets, inputs from the wrong player slot, inputs for a match that ended), and no rate-limit test. For a publicly-exposed service these are the tests you actually need.",
+      "severity": "major"
+    },
+    {
+      "category": "weak-testing",
+      "text": "§6.2 \"Loopback match: … script a 30-second match\" does not say what the scripted inputs are or what invariants the assertion checks beyond \"`MatchResult` event is emitted and both clients exit cleanly\". Without a deterministic input script and explicit output expectations (final scores, winner identity, garbage totals) the test is unlikely to catch regressions.",
+      "severity": "major"
+    },
+    {
+      "category": "weak-testing",
+      "text": "Heartbeat/stall detection (§5.4: \"No pong for 3 s → server declares the session stalled and awards the match to the peer\") is one of the most subtle pieces of the protocol and has no unit test. §6.2 has a \"kill one client's socket\" test, but TCP-reset is not the same code path as a silent stall (no RST, just packet loss). Add a test that simulates dropped packets/zero bandwidth without closing the socket.",
+      "severity": "major"
+    },
+    {
+      "category": "weak-testing",
+      "text": "§6.1 version-mismatch test only exercises the client-newer-than-server direction (`proto_version = 2` against v1). The reverse (old client against new server) is the common rollout failure and is not tested. Add a symmetric test.",
+      "severity": "minor"
+    },
+    {
+      "category": "weak-testing",
+      "text": "Client-side snapshot-mirror correctness (SPSC slot, \"one tick behind at worst\") is called out as a key abstraction in §4.2 but has no test in §6. If the mirror tears or goes stale the render layer silently shows wrong state; this is exactly the kind of concurrency code that needs a targeted unit test with a stressing harness.",
+      "severity": "minor"
+    },
+    {
+      "category": "ambiguity",
+      "text": "§5.3 seeds garbage-gap RNG from \"match seed + tick + recipient id\", but recipient id is not defined anywhere (is it host=0/guest=1? a UUID? the room code?). Two clients computing different recipient ids will produce divergent garbage and desync the determinism test in §6.2. Pin this down.",
+      "severity": "major"
+    },
+    {
+      "category": "ambiguity",
+      "text": "§2.3 states \"No client-side prediction in v1\" but §4.2 defines a `SnapshotMirror` that the render thread reads \"each frame\" with the net thread \"one tick behind at worst\". If the render frame rate is 60 fps and the network is lossy/jittery, the render loop will either block (stutter) or display a stale tick. The spec does not say which, nor what the mirror does when no new snapshot has arrived by frame time. This is visible to players.",
+      "severity": "minor"
+    },
+    {
+      "category": "missing-requirement",
+      "text": "§9 risk table mentions \"Fixed-point only\" as the desync mitigation, but §5 Implementation details contains no subsection specifying the fixed-point representation, arithmetic rules, or conversion strategy from the existing v0.1 float-based simulation. Either add a §5.x \"Deterministic arithmetic\" subsection or drop the fixed-point commitment.",
+      "severity": "major"
+    }
+  ],
+  "summary": "The spec covers all nine mandatory baseline sections and is strong on scope discipline, topology rationale, and sprint parallelisation. The most serious gaps are: (1) the §4 architecture placeholder contradicts the populated §4.1–4.3; (2) the Sprint-1 feature-flag rule contradicts Sprint 2 shipping `mp local`; (3) garbage-exchange prose (§5.3) does not match the B2B ×1.5 table referenced by its test (§6.1); (4) RTT-vs-one-way conflated in §2.5; (5) heartbeat uses `Pong` with no `Ping` frame defined. Multiple enums (Goodbye/Error reasons), the fixed-point arithmetic scheme, sudden-death rules, and garbage queue-overflow behaviour are referenced but never specified. Testing is weak on the load-bearing claims: bandwidth budget, 200-match scale target, adversarial input validation, rate limiting, and silent-stall heartbeat timeout all lack corresponding tests. No idea-contradiction findings — the original idea contains no explicit `NOT X` disclaimers to violate.",
+  "suggested_next_version": "v0.2",
+  "usage": null,
+  "effort_used": "max"
+}
+<!-- samospec:critique end -->

--- a/.samo/spec/multiplayer-v1/reviews/r01/codex.md
+++ b/.samo/spec/multiplayer-v1/reviews/r01/codex.md
@@ -1,0 +1,101 @@
+# Reviewer A — Codex
+
+## summary
+
+The gameplay direction is workable, but this spec is not yet safe to operationalize: it under-specifies adversarial clients, resource exhaustion, routing and rollout behavior, and it accidentally gives modified clients enough randomness to cheat. Tighten the protocol and deployment model before implementation starts.
+
+## missing-risk
+
+- (major) Sec. 4.2/5.1 leaks hidden server randomness to untrusted clients: `MatchStart` sends the match `seed`, and that seed drives both 7-bag generation and garbage-hole placement. A modified client can precompute future pieces and garbage gaps for both players, which is a serious competitive-integrity break. Keep hidden RNG server-only and send only the currently visible queue state.
+- (major) Sec. 4.2/5.5 treats the 5-character room code as the only join secret, with only `JoinRoom` rate-limited per IP and no host approval step. That makes room hijack and room enumeration practical for distributed attackers or anyone who overhears a code. Add a second shared secret or host-confirm flow, plus global and per-room join throttles.
+- (major) Sec. 5.5 rate-limits `JoinRoom` attempts but says nothing about `HostRoom`, idle pre-match rooms, concurrent sockets, handshake timeouts, or per-IP room quotas. An attacker can exhaust memory and file descriptors by opening rooms or holding connections without ever starting matches. The spec needs explicit admission control, room TTLs, and hard per-connection and per-IP caps.
+- (major) Sec. 4.3 uses `bincode` on an untrusted public interface but does not specify hard decode bounds, websocket max-frame limits, or per-field size caps for strings and capability vectors. The inner `u16` length prefix is not enough unless the websocket layer is also capped before allocation. Without explicit bounds, malformed peers can turn decoding into an allocation or CPU DoS.
+- (major) Sec. 1/4.3 enforces hard protocol-version refusal, but the spec gives no deployment strategy for the official service. A routine rolling deploy or client release can strand users on version mismatches unless you version endpoints or run blue-green capacity during rollout. For a public server, compatibility policy and drain behavior need to be part of the spec.
+- (minor) Sec. 8 adds a Prometheus `/metrics` endpoint but never says where it binds or how it is protected. Exposing it on the public interface leaks operational state and creates another parser surface for attackers. Bind it to localhost or an admin network only, or put it behind explicit auth.
+
+## weak-implementation
+
+- (major) Sec. 2.3/4.3 has no backpressure policy for slow or malicious clients even though snapshots are pushed unconditionally at 60 Hz and delta state is tracked per client. If a client stops acking or reading, outbound buffers and diff history can grow until they become a server-side DoS. Specify bounded queues, snapshot coalescing/drop-old behavior, and a disconnect threshold for lagging peers.
+- (major) Sec. 2.3 says the server applies input at `client_tick + INPUT_DELAY`, but the spec never defines how client tick is synchronized, bounded, or corrected for drift. As written, a hostile client can lie about `client_tick` to reduce effective delay, inject far-future inputs, or force oversized reorder windows. The server should assign authoritative input slots or at minimum enforce a narrow accept window around server time.
+- (major) Sec. 2.2 claims the server is 'stateless between matches and horizontally scalable', but room codes, waiting rooms, and active matches are all long-lived in-memory state. Without a shared room directory and sticky routing, or a single authoritative ingress, horizontal scaling and failover are not actually defined. This is an ops hole, not just an implementation detail.
+- (minor) Sec. 5.4 is internally inconsistent on liveness: the client is said to send `Pong(nonce)` every 500 ms and the server replies, but the protocol table only defines `Pong` and never defines `Ping`. This is likely to produce mismatched implementations and weak liveness semantics. Define a server-initiated `Ping`/client `Pong` pair or a clearly named client heartbeat.
+
+## unnecessary-scope
+
+- (minor) Sec. 5.6/8 keeps `mp local` in the v1 delivery scope even though it requires split-screen TTY UX, separate local input mapping, extra QA, and an offline-syscall guarantee that does not harden the internet-facing service. For a risky first public multiplayer release, this is scope competing directly with protocol hardening and abuse controls.
+- (minor) Sec. 2.4 never states that websocket compression and nonessential extensions are disabled. For tiny binary frames in a CLI game, permessage-deflate is upside-down risk: more CPU and memory complexity, worse DoS characteristics, and no meaningful product benefit. Explicitly turn compression and optional extensions off in v1.
+
+## suggested-next-version
+
+v0.1.1
+
+<!-- samospec:critique v1 -->
+{
+  "findings": [
+    {
+      "category": "missing-risk",
+      "text": "Sec. 4.2/5.1 leaks hidden server randomness to untrusted clients: `MatchStart` sends the match `seed`, and that seed drives both 7-bag generation and garbage-hole placement. A modified client can precompute future pieces and garbage gaps for both players, which is a serious competitive-integrity break. Keep hidden RNG server-only and send only the currently visible queue state.",
+      "severity": "major"
+    },
+    {
+      "category": "missing-risk",
+      "text": "Sec. 4.2/5.5 treats the 5-character room code as the only join secret, with only `JoinRoom` rate-limited per IP and no host approval step. That makes room hijack and room enumeration practical for distributed attackers or anyone who overhears a code. Add a second shared secret or host-confirm flow, plus global and per-room join throttles.",
+      "severity": "major"
+    },
+    {
+      "category": "missing-risk",
+      "text": "Sec. 5.5 rate-limits `JoinRoom` attempts but says nothing about `HostRoom`, idle pre-match rooms, concurrent sockets, handshake timeouts, or per-IP room quotas. An attacker can exhaust memory and file descriptors by opening rooms or holding connections without ever starting matches. The spec needs explicit admission control, room TTLs, and hard per-connection and per-IP caps.",
+      "severity": "major"
+    },
+    {
+      "category": "weak-implementation",
+      "text": "Sec. 2.3/4.3 has no backpressure policy for slow or malicious clients even though snapshots are pushed unconditionally at 60 Hz and delta state is tracked per client. If a client stops acking or reading, outbound buffers and diff history can grow until they become a server-side DoS. Specify bounded queues, snapshot coalescing/drop-old behavior, and a disconnect threshold for lagging peers.",
+      "severity": "major"
+    },
+    {
+      "category": "weak-implementation",
+      "text": "Sec. 2.3 says the server applies input at `client_tick + INPUT_DELAY`, but the spec never defines how client tick is synchronized, bounded, or corrected for drift. As written, a hostile client can lie about `client_tick` to reduce effective delay, inject far-future inputs, or force oversized reorder windows. The server should assign authoritative input slots or at minimum enforce a narrow accept window around server time.",
+      "severity": "major"
+    },
+    {
+      "category": "missing-risk",
+      "text": "Sec. 4.3 uses `bincode` on an untrusted public interface but does not specify hard decode bounds, websocket max-frame limits, or per-field size caps for strings and capability vectors. The inner `u16` length prefix is not enough unless the websocket layer is also capped before allocation. Without explicit bounds, malformed peers can turn decoding into an allocation or CPU DoS.",
+      "severity": "major"
+    },
+    {
+      "category": "weak-implementation",
+      "text": "Sec. 2.2 claims the server is 'stateless between matches and horizontally scalable', but room codes, waiting rooms, and active matches are all long-lived in-memory state. Without a shared room directory and sticky routing, or a single authoritative ingress, horizontal scaling and failover are not actually defined. This is an ops hole, not just an implementation detail.",
+      "severity": "major"
+    },
+    {
+      "category": "missing-risk",
+      "text": "Sec. 1/4.3 enforces hard protocol-version refusal, but the spec gives no deployment strategy for the official service. A routine rolling deploy or client release can strand users on version mismatches unless you version endpoints or run blue-green capacity during rollout. For a public server, compatibility policy and drain behavior need to be part of the spec.",
+      "severity": "major"
+    },
+    {
+      "category": "weak-implementation",
+      "text": "Sec. 5.4 is internally inconsistent on liveness: the client is said to send `Pong(nonce)` every 500 ms and the server replies, but the protocol table only defines `Pong` and never defines `Ping`. This is likely to produce mismatched implementations and weak liveness semantics. Define a server-initiated `Ping`/client `Pong` pair or a clearly named client heartbeat.",
+      "severity": "minor"
+    },
+    {
+      "category": "missing-risk",
+      "text": "Sec. 8 adds a Prometheus `/metrics` endpoint but never says where it binds or how it is protected. Exposing it on the public interface leaks operational state and creates another parser surface for attackers. Bind it to localhost or an admin network only, or put it behind explicit auth.",
+      "severity": "minor"
+    },
+    {
+      "category": "unnecessary-scope",
+      "text": "Sec. 5.6/8 keeps `mp local` in the v1 delivery scope even though it requires split-screen TTY UX, separate local input mapping, extra QA, and an offline-syscall guarantee that does not harden the internet-facing service. For a risky first public multiplayer release, this is scope competing directly with protocol hardening and abuse controls.",
+      "severity": "minor"
+    },
+    {
+      "category": "unnecessary-scope",
+      "text": "Sec. 2.4 never states that websocket compression and nonessential extensions are disabled. For tiny binary frames in a CLI game, permessage-deflate is upside-down risk: more CPU and memory complexity, worse DoS characteristics, and no meaningful product benefit. Explicitly turn compression and optional extensions off in v1.",
+      "severity": "minor"
+    }
+  ],
+  "summary": "The gameplay direction is workable, but this spec is not yet safe to operationalize: it under-specifies adversarial clients, resource exhaustion, routing and rollout behavior, and it accidentally gives modified clients enough randomness to cheat. Tighten the protocol and deployment model before implementation starts.",
+  "suggested_next_version": "v0.1.1",
+  "usage": null,
+  "effort_used": "max"
+}
+<!-- samospec:critique end -->

--- a/.samo/spec/multiplayer-v1/reviews/r01/codex.md
+++ b/.samo/spec/multiplayer-v1/reviews/r01/codex.md
@@ -2,99 +2,87 @@
 
 ## summary
 
-The gameplay direction is workable, but this spec is not yet safe to operationalize: it under-specifies adversarial clients, resource exhaustion, routing and rollout behavior, and it accidentally gives modified clients enough randomness to cheat. Tighten the protocol and deployment model before implementation starts.
+The gameplay direction is plausible, but the spec is not yet safe to treat as a public-server rollout. The main gaps are room-level authentication, explicit abuse/resource controls, bounded snapshot/backpressure behavior, and deployment/routing details, while v1 scope still spends effort on mp local instead of hardening those basics.
 
 ## missing-risk
 
-- (major) Sec. 4.2/5.1 leaks hidden server randomness to untrusted clients: `MatchStart` sends the match `seed`, and that seed drives both 7-bag generation and garbage-hole placement. A modified client can precompute future pieces and garbage gaps for both players, which is a serious competitive-integrity break. Keep hidden RNG server-only and send only the currently visible queue state.
-- (major) Sec. 4.2/5.5 treats the 5-character room code as the only join secret, with only `JoinRoom` rate-limited per IP and no host approval step. That makes room hijack and room enumeration practical for distributed attackers or anyone who overhears a code. Add a second shared secret or host-confirm flow, plus global and per-room join throttles.
-- (major) Sec. 5.5 rate-limits `JoinRoom` attempts but says nothing about `HostRoom`, idle pre-match rooms, concurrent sockets, handshake timeouts, or per-IP room quotas. An attacker can exhaust memory and file descriptors by opening rooms or holding connections without ever starting matches. The spec needs explicit admission control, room TTLs, and hard per-connection and per-IP caps.
-- (major) Sec. 4.3 uses `bincode` on an untrusted public interface but does not specify hard decode bounds, websocket max-frame limits, or per-field size caps for strings and capability vectors. The inner `u16` length prefix is not enough unless the websocket layer is also capped before allocation. Without explicit bounds, malformed peers can turn decoding into an allocation or CPU DoS.
-- (major) Sec. 1/4.3 enforces hard protocol-version refusal, but the spec gives no deployment strategy for the official service. A routine rolling deploy or client release can strand users on version mismatches unless you version endpoints or run blue-green capacity during rollout. For a public server, compatibility policy and drain behavior need to be part of the spec.
-- (minor) Sec. 8 adds a Prometheus `/metrics` endpoint but never says where it binds or how it is protected. Exposing it on the public interface leaks operational state and creates another parser surface for attackers. Bind it to localhost or an admin network only, or put it behind explicit auth.
+- (major) Section 4.2/5.5 make the 5-character room code the only join credential. There is no host-side admit/confirm step and no second secret, so anyone who overhears or guesses the code can steal the guest slot and grief the match; the current JoinRoom IP rate limit only slows brute force, it does not protect an individual room.
+- (major) Section 5.5 rate-limits only JoinRoom. The spec omits limits for HostRoom creation, idle pre-match room lifetime, concurrent TLS/WebSocket sessions per IP, invalid-frame budgets, and total rooms per node, which leaves a public unauthenticated service on port 443 trivially exhaustible with cheap idle sockets or room spam.
+- (major) Section 2.5 asserts 200 concurrent matches per 1-vCPU node, but the spec never defines admission control or overload behavior. Without explicit caps that reject new rooms/sessions before tick budget is breached, one spike or attack will degrade every active match instead of failing closed.
+- (major) Section 4.3 length-prefixing and fuzzing are not enough for a public parser. The spec does not set a maximum WebSocket message size, maximum decoded allocation, per-connection outbound queue depth, or malformed-frame CPU/ban thresholds, so a single peer can force large allocations or sustained decode work.
+- (major) Section 2.2 says the server is stateless between matches and horizontally scalable, but active room-code matchmaking requires either shared room state or sticky routing from host/join through match end. Without that routing/registry design, the first multi-instance deployment will break rendezvous or force a late rewrite.
+- (minor) Section 8 adds a Prometheus /metrics endpoint but never says it is bound to localhost/private networking or otherwise authenticated. Exposing live concurrency and tick-budget data on the public game service gives attackers free capacity reconnaissance and unnecessary extra attack surface.
+- (major) Section 4.3/3 expect the client to print server-provided human-readable Error strings as actionable terminal output. The spec does not require control-character stripping or length limits, so a malicious or self-hosted server can inject ANSI escapes, spoof prompts, or leave the terminal in a bad state.
 
 ## weak-implementation
 
-- (major) Sec. 2.3/4.3 has no backpressure policy for slow or malicious clients even though snapshots are pushed unconditionally at 60 Hz and delta state is tracked per client. If a client stops acking or reading, outbound buffers and diff history can grow until they become a server-side DoS. Specify bounded queues, snapshot coalescing/drop-old behavior, and a disconnect threshold for lagging peers.
-- (major) Sec. 2.3 says the server applies input at `client_tick + INPUT_DELAY`, but the spec never defines how client tick is synchronized, bounded, or corrected for drift. As written, a hostile client can lie about `client_tick` to reduce effective delay, inject far-future inputs, or force oversized reorder windows. The server should assign authoritative input slots or at minimum enforce a narrow accept window around server time.
-- (major) Sec. 2.2 claims the server is 'stateless between matches and horizontally scalable', but room codes, waiting rooms, and active matches are all long-lived in-memory state. Without a shared room directory and sticky routing, or a single authoritative ingress, horizontal scaling and failover are not actually defined. This is an ops hole, not just an implementation detail.
-- (minor) Sec. 5.4 is internally inconsistent on liveness: the client is said to send `Pong(nonce)` every 500 ms and the server replies, but the protocol table only defines `Pong` and never defines `Ping`. This is likely to produce mismatched implementations and weak liveness semantics. Define a server-initiated `Ping`/client `Pong` pair or a clearly named client heartbeat.
+- (major) Section 2.3/4.3 delta-compress snapshots against the last acked snapshot and still send every tick when acks stall. That leaves the server with no bounded recovery path for slow or malicious clients; it needs a finite ack window plus periodic keyframes/backoff/disconnect rules, or memory/CPU can grow around a single lagging socket.
+- (minor) Section 5.5 logging as match_id plus truncated IP hash is under-specified. Without a keyed rotating salt, IPv4 hashes are brute-forceable; with too much truncation they stop being useful for abuse correlation, so the current text gives neither a strong privacy guarantee nor a reliable incident-response handle.
 
 ## unnecessary-scope
 
-- (minor) Sec. 5.6/8 keeps `mp local` in the v1 delivery scope even though it requires split-screen TTY UX, separate local input mapping, extra QA, and an offline-syscall guarantee that does not harden the internet-facing service. For a risky first public multiplayer release, this is scope competing directly with protocol hardening and abuse controls.
-- (minor) Sec. 2.4 never states that websocket compression and nonessential extensions are disabled. For tiny binary frames in a CLI game, permessage-deflate is upside-down risk: more CPU and memory complexity, worse DoS characteristics, and no meaningful product benefit. Explicitly turn compression and optional extensions off in v1.
+- (minor) Section 5.6/8 make mp local a first-class public feature in the same release. For v1 this is unnecessary scope: it adds split-screen TTY/input-multiplexing and extra regression surface in the offline-default binary, but it does not reduce the security or operational risk of the public server. Keep it as an internal harness or defer it.
 
 ## suggested-next-version
 
-v0.1.1
+Narrow the next revision to online 1v1 on a single-region beta and make the server model explicit: add host admission or a second join secret, idle-room/session/frame-size/concurrency limits, overload/load-shedding rules, a bounded ack window plus periodic keyframes, private-only metrics, sanitized terminal strings, and a keyed rotating IP-hash policy; defer mp local unless it is re-scoped as an internal test harness.
 
 <!-- samospec:critique v1 -->
 {
   "findings": [
     {
       "category": "missing-risk",
-      "text": "Sec. 4.2/5.1 leaks hidden server randomness to untrusted clients: `MatchStart` sends the match `seed`, and that seed drives both 7-bag generation and garbage-hole placement. A modified client can precompute future pieces and garbage gaps for both players, which is a serious competitive-integrity break. Keep hidden RNG server-only and send only the currently visible queue state.",
+      "text": "Section 4.2/5.5 make the 5-character room code the only join credential. There is no host-side admit/confirm step and no second secret, so anyone who overhears or guesses the code can steal the guest slot and grief the match; the current JoinRoom IP rate limit only slows brute force, it does not protect an individual room.",
       "severity": "major"
     },
     {
       "category": "missing-risk",
-      "text": "Sec. 4.2/5.5 treats the 5-character room code as the only join secret, with only `JoinRoom` rate-limited per IP and no host approval step. That makes room hijack and room enumeration practical for distributed attackers or anyone who overhears a code. Add a second shared secret or host-confirm flow, plus global and per-room join throttles.",
+      "text": "Section 5.5 rate-limits only JoinRoom. The spec omits limits for HostRoom creation, idle pre-match room lifetime, concurrent TLS/WebSocket sessions per IP, invalid-frame budgets, and total rooms per node, which leaves a public unauthenticated service on port 443 trivially exhaustible with cheap idle sockets or room spam.",
       "severity": "major"
     },
     {
       "category": "missing-risk",
-      "text": "Sec. 5.5 rate-limits `JoinRoom` attempts but says nothing about `HostRoom`, idle pre-match rooms, concurrent sockets, handshake timeouts, or per-IP room quotas. An attacker can exhaust memory and file descriptors by opening rooms or holding connections without ever starting matches. The spec needs explicit admission control, room TTLs, and hard per-connection and per-IP caps.",
+      "text": "Section 2.5 asserts 200 concurrent matches per 1-vCPU node, but the spec never defines admission control or overload behavior. Without explicit caps that reject new rooms/sessions before tick budget is breached, one spike or attack will degrade every active match instead of failing closed.",
       "severity": "major"
     },
     {
       "category": "weak-implementation",
-      "text": "Sec. 2.3/4.3 has no backpressure policy for slow or malicious clients even though snapshots are pushed unconditionally at 60 Hz and delta state is tracked per client. If a client stops acking or reading, outbound buffers and diff history can grow until they become a server-side DoS. Specify bounded queues, snapshot coalescing/drop-old behavior, and a disconnect threshold for lagging peers.",
-      "severity": "major"
-    },
-    {
-      "category": "weak-implementation",
-      "text": "Sec. 2.3 says the server applies input at `client_tick + INPUT_DELAY`, but the spec never defines how client tick is synchronized, bounded, or corrected for drift. As written, a hostile client can lie about `client_tick` to reduce effective delay, inject far-future inputs, or force oversized reorder windows. The server should assign authoritative input slots or at minimum enforce a narrow accept window around server time.",
+      "text": "Section 2.3/4.3 delta-compress snapshots against the last acked snapshot and still send every tick when acks stall. That leaves the server with no bounded recovery path for slow or malicious clients; it needs a finite ack window plus periodic keyframes/backoff/disconnect rules, or memory/CPU can grow around a single lagging socket.",
       "severity": "major"
     },
     {
       "category": "missing-risk",
-      "text": "Sec. 4.3 uses `bincode` on an untrusted public interface but does not specify hard decode bounds, websocket max-frame limits, or per-field size caps for strings and capability vectors. The inner `u16` length prefix is not enough unless the websocket layer is also capped before allocation. Without explicit bounds, malformed peers can turn decoding into an allocation or CPU DoS.",
-      "severity": "major"
-    },
-    {
-      "category": "weak-implementation",
-      "text": "Sec. 2.2 claims the server is 'stateless between matches and horizontally scalable', but room codes, waiting rooms, and active matches are all long-lived in-memory state. Without a shared room directory and sticky routing, or a single authoritative ingress, horizontal scaling and failover are not actually defined. This is an ops hole, not just an implementation detail.",
+      "text": "Section 4.3 length-prefixing and fuzzing are not enough for a public parser. The spec does not set a maximum WebSocket message size, maximum decoded allocation, per-connection outbound queue depth, or malformed-frame CPU/ban thresholds, so a single peer can force large allocations or sustained decode work.",
       "severity": "major"
     },
     {
       "category": "missing-risk",
-      "text": "Sec. 1/4.3 enforces hard protocol-version refusal, but the spec gives no deployment strategy for the official service. A routine rolling deploy or client release can strand users on version mismatches unless you version endpoints or run blue-green capacity during rollout. For a public server, compatibility policy and drain behavior need to be part of the spec.",
+      "text": "Section 2.2 says the server is stateless between matches and horizontally scalable, but active room-code matchmaking requires either shared room state or sticky routing from host/join through match end. Without that routing/registry design, the first multi-instance deployment will break rendezvous or force a late rewrite.",
       "severity": "major"
     },
     {
-      "category": "weak-implementation",
-      "text": "Sec. 5.4 is internally inconsistent on liveness: the client is said to send `Pong(nonce)` every 500 ms and the server replies, but the protocol table only defines `Pong` and never defines `Ping`. This is likely to produce mismatched implementations and weak liveness semantics. Define a server-initiated `Ping`/client `Pong` pair or a clearly named client heartbeat.",
+      "category": "missing-risk",
+      "text": "Section 8 adds a Prometheus /metrics endpoint but never says it is bound to localhost/private networking or otherwise authenticated. Exposing live concurrency and tick-budget data on the public game service gives attackers free capacity reconnaissance and unnecessary extra attack surface.",
       "severity": "minor"
     },
     {
       "category": "missing-risk",
-      "text": "Sec. 8 adds a Prometheus `/metrics` endpoint but never says where it binds or how it is protected. Exposing it on the public interface leaks operational state and creates another parser surface for attackers. Bind it to localhost or an admin network only, or put it behind explicit auth.",
-      "severity": "minor"
+      "text": "Section 4.3/3 expect the client to print server-provided human-readable Error strings as actionable terminal output. The spec does not require control-character stripping or length limits, so a malicious or self-hosted server can inject ANSI escapes, spoof prompts, or leave the terminal in a bad state.",
+      "severity": "major"
     },
     {
       "category": "unnecessary-scope",
-      "text": "Sec. 5.6/8 keeps `mp local` in the v1 delivery scope even though it requires split-screen TTY UX, separate local input mapping, extra QA, and an offline-syscall guarantee that does not harden the internet-facing service. For a risky first public multiplayer release, this is scope competing directly with protocol hardening and abuse controls.",
+      "text": "Section 5.6/8 make mp local a first-class public feature in the same release. For v1 this is unnecessary scope: it adds split-screen TTY/input-multiplexing and extra regression surface in the offline-default binary, but it does not reduce the security or operational risk of the public server. Keep it as an internal harness or defer it.",
       "severity": "minor"
     },
     {
-      "category": "unnecessary-scope",
-      "text": "Sec. 2.4 never states that websocket compression and nonessential extensions are disabled. For tiny binary frames in a CLI game, permessage-deflate is upside-down risk: more CPU and memory complexity, worse DoS characteristics, and no meaningful product benefit. Explicitly turn compression and optional extensions off in v1.",
+      "category": "weak-implementation",
+      "text": "Section 5.5 logging as match_id plus truncated IP hash is under-specified. Without a keyed rotating salt, IPv4 hashes are brute-forceable; with too much truncation they stop being useful for abuse correlation, so the current text gives neither a strong privacy guarantee nor a reliable incident-response handle.",
       "severity": "minor"
     }
   ],
-  "summary": "The gameplay direction is workable, but this spec is not yet safe to operationalize: it under-specifies adversarial clients, resource exhaustion, routing and rollout behavior, and it accidentally gives modified clients enough randomness to cheat. Tighten the protocol and deployment model before implementation starts.",
-  "suggested_next_version": "v0.1.1",
+  "summary": "The gameplay direction is plausible, but the spec is not yet safe to treat as a public-server rollout. The main gaps are room-level authentication, explicit abuse/resource controls, bounded snapshot/backpressure behavior, and deployment/routing details, while v1 scope still spends effort on mp local instead of hardening those basics.",
+  "suggested_next_version": "Narrow the next revision to online 1v1 on a single-region beta and make the server model explicit: add host admission or a second join secret, idle-room/session/frame-size/concurrency limits, overload/load-shedding rules, a bounded ack window plus periodic keyframes, private-only metrics, sanitized terminal strings, and a keyed rotating IP-hash policy; defer mp local unless it is re-scoped as an internal test harness.",
   "usage": null,
   "effort_used": "max"
 }

--- a/.samo/spec/multiplayer-v1/reviews/r01/round.json
+++ b/.samo/spec/multiplayer-v1/reviews/r01/round.json
@@ -5,6 +5,6 @@
     "reviewer_a": "ok",
     "reviewer_b": "ok"
   },
-  "started_at": "2026-04-24T04:04:02.876Z",
-  "completed_at": "2026-04-24T04:07:12.027Z"
+  "started_at": "2026-04-24T04:15:20.801Z",
+  "completed_at": "2026-04-24T04:18:26.894Z"
 }

--- a/.samo/spec/multiplayer-v1/reviews/r01/round.json
+++ b/.samo/spec/multiplayer-v1/reviews/r01/round.json
@@ -1,9 +1,10 @@
 {
   "round": 1,
-  "status": "running",
+  "status": "complete",
   "seats": {
-    "reviewer_a": "pending",
-    "reviewer_b": "pending"
+    "reviewer_a": "ok",
+    "reviewer_b": "ok"
   },
-  "started_at": "2026-04-24T04:03:52.948Z"
+  "started_at": "2026-04-24T04:04:02.876Z",
+  "completed_at": "2026-04-24T04:07:12.027Z"
 }

--- a/.samo/spec/multiplayer-v1/reviews/r01/round.json
+++ b/.samo/spec/multiplayer-v1/reviews/r01/round.json
@@ -1,0 +1,9 @@
+{
+  "round": 1,
+  "status": "running",
+  "seats": {
+    "reviewer_a": "pending",
+    "reviewer_b": "pending"
+  },
+  "started_at": "2026-04-24T04:03:52.948Z"
+}

--- a/.samo/spec/multiplayer-v1/reviews/r02/claude.md
+++ b/.samo/spec/multiplayer-v1/reviews/r02/claude.md
@@ -1,0 +1,125 @@
+# Reviewer B — Claude
+
+## summary
+
+Nine mandatory baseline sections are all present and the spec is notably mature after r1. The strongest remaining issues are (1) a genuine contradiction — §4's 'architecture not yet specified' placeholder still sits above the real architecture despite the changelog claiming this was fixed; (2) several simulation rules that are part of the wire contract but under-specified in a determinism-breaking way (WELL_WIDTH undefined, garbage-RNG modulo, aggregate-well-height tiebreak, combo formula's N, sudden-death 'every 2 s' vs. ticks, DAS-charge semantics on a per-tick bitset); and (3) a weak-testing gap where ~half of §4.4's admission/backpressure limits have no named test despite §4.4 explicitly claiming they are 'enforced in code, not just documentation'. No idea-contradiction findings: the original idea contained no explicit disclaimers to re-check against the spec.
+
+## contradiction
+
+- (major) §4 still contains an architecture placeholder block (`<!-- architecture:begin -->` … `(architecture not yet specified)` … `<!-- architecture:end -->`) sitting directly above §4.1's actual ASCII diagram. This is exactly the defect the v0.2 changelog claims to have fixed ('fixed architecture placeholder contradiction'), yet the placeholder text is still in the file. Either the placeholder must be removed, or the machine-readable fence must wrap the real §4.1 diagram.
+
+## ambiguity
+
+- (major) §5.3.2 defines the sudden-death tiebreak as 'the player with the lower aggregate well height', but 'aggregate well height' is never defined. It could mean sum of per-column stack heights, max column height, total non-empty cells, or something else; each yields different winners in realistic same-tick double top-outs. Determinism of the tiebreak is claimed but un-specified at the mechanic level, and §6.1 lists no test that pins which definition wins.
+- (major) §5.3.1 row 'Combo (N consecutive clears ≥ 2)  floor((N-1)/2)' is under-specified. It is unclear (a) whether 'N' is the current chain length including this clear or the previous chain length, (b) whether 'clears ≥ 2' means each clear must be at least a double, or the combo chain must be ≥ 2 long, and (c) how N resets (on non-clear drop? on a single-line clear?). Different readings differ by ±1 row sent on most combos, so the §6.1 'every row of §5.3.1' test cannot be written deterministically against this table.
+- (major) §5.3.3 pins the garbage RNG derivation as 'first u8 % WELL_WIDTH output is the gap column', but WELL_WIDTH is not defined anywhere in the spec (no mention in §4, §5, or §6), and a naive `u8 % W` introduces modulo bias unless W divides 256 evenly. The spec declares this derivation part of the wire contract and requires a cross-platform golden vector, yet two conforming implementations can produce different gap columns just by choosing different rejection-sampling strategies.
+- (major) §4.3 defines `Input` bit 4 as 'DAS-charge', but DAS (delayed auto-shift) is a continuous/stateful client concept — a player holds a direction for N ms and then auto-repeats. A per-tick bitset cannot naturally encode 'charge state'. The spec does not say whether the bit means 'DAS is currently charged', 'consume DAS charge this tick', or 'begin charging'. §5.5.1 claims the server validates every Input as a 'named move', but DAS-charge is not a move. This is both an ambiguity and a contradiction with the §4.3/§5.5.1 validation story, and no §6.1 test nails down the semantics.
+- (minor) §5.3.1 B2B bonus is '+1 flat, (consecutive quad/T-spin)' but it is not stated whether the +1 applies once per B2B chain start, or per subsequent qualifying clear in the chain. The manual test §6.4 asserts 'B2B quad sends 5 rows (4 + 1)', implying per-clear, but the table text is compatible with either reading. §6.1 should explicitly name the per-clear semantics in a test case.
+- (minor) §2.5 claims 'the 150 ms budget is the figure §2.3 uses when it calls RTT + 2-tick input delay imperceptible', but §2.3 nowhere names 150 ms, RTT, or 'imperceptible' — it only says the input delay 'absorbs typical jitter without visible lag'. The self-referential cross-reference is broken and a reviewer cannot verify the RTT budget rationale from §2.3 alone.
+- (minor) §5.3.1 'drain cap: up to 8 rows inserted per piece-spawn' does not define 'piece-spawn'. Candidate meanings: every time a new tetromino becomes the active piece (post-lock), every 'next' advance, or every lock-and-respawn including after a clear. Each yields different garbage-delivery cadence under heavy pressure; §6.1 asserts 'drain cap of 8 … leaves the correct residue' but 'correct' is undefined until 'piece-spawn' is.
+- (minor) §5.3.2 says 'an extra garbage row is inserted into each well every 2 s' during sudden-death. 2 s at 60 Hz is 120 ticks, but the spec elsewhere forbids wall-clock time in the simulation (§5.1) and the spec does not state 'every 120 ticks starting at tick 36000'. Leaving this as a wall-clock-flavored rule contradicts the determinism contract.
+- (minor) §5.2 state-transition diagram omits the `AwaitingAdmit` → (host declines or 15 s timeout) branch, even though §4.4 and user story 2 rely on it. A reviewer following only the diagram cannot determine which state the host returns to after declining, nor what the guest sees.
+- (minor) §5.5.3 rotates the IP-hash salt every 24 h, but §4.3 `JoinRequest.peer_ip_hash` is shown to the host for admission (§4.4). If the host is in an extended session across a rotation, the same joiner IP will hash differently on either side of rotation, defeating host-side correlation ('is this the same guy who just tried to join?'). The spec does not state whether JoinRequest uses the currently-active salt, a session-pinned salt, or a host-scoped secondary salt.
+
+## weak-testing
+
+- (major) §4.4 enumerates seven admission limits (HostRoom/min, JoinRoom/min, WS sessions per IP = 8, rooms per IP as host = 2, total sessions per node = 1024, server outbound queue depth per client = 8, invalid-frame budget 4 / 10 s), but §6 only tests JoinRoom, HostRoom, and the 256-match cap explicitly. The per-IP session cap, per-IP host-room cap, per-node session cap, outbound queue overflow → close, and invalid-frame-budget → close all lack any named test. A reviewer cannot verify §4.4 is 'enforced in code, not just documentation' as the §4.4 preamble claims.
+- (minor) §6.2 bandwidth test asserts '≤ 8 KiB/s mean and ≤ 32 KiB/s peak' but does not define the averaging window for 'peak' (1 s? 1 tick? 100 ms?). A flaky peak is almost guaranteed without this; the test is underspecified and will either rubber-stamp or randomly fail.
+- (minor) §6.1 'Input-delay pipeline' asserts 'late inputs are dropped and logged as InputTooLate', but 'late' is not defined in §2.3 or §5.5.1 — is an input late if its client_tick is strictly less than the server's current apply tick, or strictly less than server_tick + INPUT_DELAY, or something else? The test references a term the spec does not pin down.
+- (minor) §5.3.4 defines four HUD colour-ramp thresholds for pending-garbage rows (hidden / DIM / OVERLAY / NEW_BEST / flashing-at-capped), and §5.3.3 pins deterministic thresholds, but §6.1/§6.2 list no test that verifies thresholds flip at exactly 1, 4, 8, and cap. Given the spec explicitly calls these 'deterministic thresholds', the test plan should too.
+- (minor) §4.4 'Server inbound frame rate per client 240 frames/s sustained' has no test. A nominal session sends ~60 Inputs/s + ~2 Pings/s + ~60 Acks/s ≈ 122 frames/s, so the 240 threshold's headroom is unverified; the spec also doesn't document what 'sustained' means (windowed over what interval).
+
+## suggested-next-version
+
+v0.3
+
+<!-- samospec:critique v1 -->
+{
+  "findings": [
+    {
+      "category": "contradiction",
+      "text": "§4 still contains an architecture placeholder block (`<!-- architecture:begin -->` … `(architecture not yet specified)` … `<!-- architecture:end -->`) sitting directly above §4.1's actual ASCII diagram. This is exactly the defect the v0.2 changelog claims to have fixed ('fixed architecture placeholder contradiction'), yet the placeholder text is still in the file. Either the placeholder must be removed, or the machine-readable fence must wrap the real §4.1 diagram.",
+      "severity": "major"
+    },
+    {
+      "category": "ambiguity",
+      "text": "§5.3.2 defines the sudden-death tiebreak as 'the player with the lower aggregate well height', but 'aggregate well height' is never defined. It could mean sum of per-column stack heights, max column height, total non-empty cells, or something else; each yields different winners in realistic same-tick double top-outs. Determinism of the tiebreak is claimed but un-specified at the mechanic level, and §6.1 lists no test that pins which definition wins.",
+      "severity": "major"
+    },
+    {
+      "category": "ambiguity",
+      "text": "§5.3.1 row 'Combo (N consecutive clears ≥ 2)  floor((N-1)/2)' is under-specified. It is unclear (a) whether 'N' is the current chain length including this clear or the previous chain length, (b) whether 'clears ≥ 2' means each clear must be at least a double, or the combo chain must be ≥ 2 long, and (c) how N resets (on non-clear drop? on a single-line clear?). Different readings differ by ±1 row sent on most combos, so the §6.1 'every row of §5.3.1' test cannot be written deterministically against this table.",
+      "severity": "major"
+    },
+    {
+      "category": "ambiguity",
+      "text": "§5.3.3 pins the garbage RNG derivation as 'first u8 % WELL_WIDTH output is the gap column', but WELL_WIDTH is not defined anywhere in the spec (no mention in §4, §5, or §6), and a naive `u8 % W` introduces modulo bias unless W divides 256 evenly. The spec declares this derivation part of the wire contract and requires a cross-platform golden vector, yet two conforming implementations can produce different gap columns just by choosing different rejection-sampling strategies.",
+      "severity": "major"
+    },
+    {
+      "category": "ambiguity",
+      "text": "§4.3 defines `Input` bit 4 as 'DAS-charge', but DAS (delayed auto-shift) is a continuous/stateful client concept — a player holds a direction for N ms and then auto-repeats. A per-tick bitset cannot naturally encode 'charge state'. The spec does not say whether the bit means 'DAS is currently charged', 'consume DAS charge this tick', or 'begin charging'. §5.5.1 claims the server validates every Input as a 'named move', but DAS-charge is not a move. This is both an ambiguity and a contradiction with the §4.3/§5.5.1 validation story, and no §6.1 test nails down the semantics.",
+      "severity": "major"
+    },
+    {
+      "category": "ambiguity",
+      "text": "§5.3.1 B2B bonus is '+1 flat, (consecutive quad/T-spin)' but it is not stated whether the +1 applies once per B2B chain start, or per subsequent qualifying clear in the chain. The manual test §6.4 asserts 'B2B quad sends 5 rows (4 + 1)', implying per-clear, but the table text is compatible with either reading. §6.1 should explicitly name the per-clear semantics in a test case.",
+      "severity": "minor"
+    },
+    {
+      "category": "ambiguity",
+      "text": "§2.5 claims 'the 150 ms budget is the figure §2.3 uses when it calls RTT + 2-tick input delay imperceptible', but §2.3 nowhere names 150 ms, RTT, or 'imperceptible' — it only says the input delay 'absorbs typical jitter without visible lag'. The self-referential cross-reference is broken and a reviewer cannot verify the RTT budget rationale from §2.3 alone.",
+      "severity": "minor"
+    },
+    {
+      "category": "ambiguity",
+      "text": "§5.3.1 'drain cap: up to 8 rows inserted per piece-spawn' does not define 'piece-spawn'. Candidate meanings: every time a new tetromino becomes the active piece (post-lock), every 'next' advance, or every lock-and-respawn including after a clear. Each yields different garbage-delivery cadence under heavy pressure; §6.1 asserts 'drain cap of 8 … leaves the correct residue' but 'correct' is undefined until 'piece-spawn' is.",
+      "severity": "minor"
+    },
+    {
+      "category": "ambiguity",
+      "text": "§5.3.2 says 'an extra garbage row is inserted into each well every 2 s' during sudden-death. 2 s at 60 Hz is 120 ticks, but the spec elsewhere forbids wall-clock time in the simulation (§5.1) and the spec does not state 'every 120 ticks starting at tick 36000'. Leaving this as a wall-clock-flavored rule contradicts the determinism contract.",
+      "severity": "minor"
+    },
+    {
+      "category": "ambiguity",
+      "text": "§5.2 state-transition diagram omits the `AwaitingAdmit` → (host declines or 15 s timeout) branch, even though §4.4 and user story 2 rely on it. A reviewer following only the diagram cannot determine which state the host returns to after declining, nor what the guest sees.",
+      "severity": "minor"
+    },
+    {
+      "category": "weak-testing",
+      "text": "§4.4 enumerates seven admission limits (HostRoom/min, JoinRoom/min, WS sessions per IP = 8, rooms per IP as host = 2, total sessions per node = 1024, server outbound queue depth per client = 8, invalid-frame budget 4 / 10 s), but §6 only tests JoinRoom, HostRoom, and the 256-match cap explicitly. The per-IP session cap, per-IP host-room cap, per-node session cap, outbound queue overflow → close, and invalid-frame-budget → close all lack any named test. A reviewer cannot verify §4.4 is 'enforced in code, not just documentation' as the §4.4 preamble claims.",
+      "severity": "major"
+    },
+    {
+      "category": "weak-testing",
+      "text": "§6.2 bandwidth test asserts '≤ 8 KiB/s mean and ≤ 32 KiB/s peak' but does not define the averaging window for 'peak' (1 s? 1 tick? 100 ms?). A flaky peak is almost guaranteed without this; the test is underspecified and will either rubber-stamp or randomly fail.",
+      "severity": "minor"
+    },
+    {
+      "category": "weak-testing",
+      "text": "§6.1 'Input-delay pipeline' asserts 'late inputs are dropped and logged as InputTooLate', but 'late' is not defined in §2.3 or §5.5.1 — is an input late if its client_tick is strictly less than the server's current apply tick, or strictly less than server_tick + INPUT_DELAY, or something else? The test references a term the spec does not pin down.",
+      "severity": "minor"
+    },
+    {
+      "category": "weak-testing",
+      "text": "§5.3.4 defines four HUD colour-ramp thresholds for pending-garbage rows (hidden / DIM / OVERLAY / NEW_BEST / flashing-at-capped), and §5.3.3 pins deterministic thresholds, but §6.1/§6.2 list no test that verifies thresholds flip at exactly 1, 4, 8, and cap. Given the spec explicitly calls these 'deterministic thresholds', the test plan should too.",
+      "severity": "minor"
+    },
+    {
+      "category": "weak-testing",
+      "text": "§4.4 'Server inbound frame rate per client 240 frames/s sustained' has no test. A nominal session sends ~60 Inputs/s + ~2 Pings/s + ~60 Acks/s ≈ 122 frames/s, so the 240 threshold's headroom is unverified; the spec also doesn't document what 'sustained' means (windowed over what interval).",
+      "severity": "minor"
+    },
+    {
+      "category": "ambiguity",
+      "text": "§5.5.3 rotates the IP-hash salt every 24 h, but §4.3 `JoinRequest.peer_ip_hash` is shown to the host for admission (§4.4). If the host is in an extended session across a rotation, the same joiner IP will hash differently on either side of rotation, defeating host-side correlation ('is this the same guy who just tried to join?'). The spec does not state whether JoinRequest uses the currently-active salt, a session-pinned salt, or a host-scoped secondary salt.",
+      "severity": "minor"
+    }
+  ],
+  "summary": "Nine mandatory baseline sections are all present and the spec is notably mature after r1. The strongest remaining issues are (1) a genuine contradiction — §4's 'architecture not yet specified' placeholder still sits above the real architecture despite the changelog claiming this was fixed; (2) several simulation rules that are part of the wire contract but under-specified in a determinism-breaking way (WELL_WIDTH undefined, garbage-RNG modulo, aggregate-well-height tiebreak, combo formula's N, sudden-death 'every 2 s' vs. ticks, DAS-charge semantics on a per-tick bitset); and (3) a weak-testing gap where ~half of §4.4's admission/backpressure limits have no named test despite §4.4 explicitly claiming they are 'enforced in code, not just documentation'. No idea-contradiction findings: the original idea contained no explicit disclaimers to re-check against the spec.",
+  "suggested_next_version": "v0.3",
+  "usage": null,
+  "effort_used": "max"
+}
+<!-- samospec:critique end -->

--- a/.samo/spec/multiplayer-v1/reviews/r02/codex.md
+++ b/.samo/spec/multiplayer-v1/reviews/r02/codex.md
@@ -1,0 +1,77 @@
+# Reviewer A — Codex
+
+## summary
+
+Primary blockers are the fake second factor in host admission, unnecessary exposure of RNG state, and missing public-edge abuse controls. The spec is tighter than before, but several controls are written as if they solve an attack class when they mostly relocate it.
+
+## weak-implementation
+
+- (major) §3 says the host sees a raw IP, but §4.4/§5.5 replace that with a keyed IP hash. A keyed hash is not human-verifiable, so the host still cannot distinguish the intended friend from the first attacker who guessed or brute-forced the code; the claimed 'second credential' is therefore mostly illusory. Add a join fingerprint/PIN that both humans can compare, or make invites single-use and host-generated.
+- (major) §2.3/§4.3 define `seq` and `client_tick`, but the spec never defines duplicate handling, monotonicity rules, or max future skew. A malicious client can replay old inputs or send far-future ones to grow per-match queues, waste CPU on validation, or create ambiguous ordering semantics. Define a strict acceptance window and disconnect on violation.
+- (minor) §4.5 allows server-originated text to keep `\n`. That blocks ANSI escapes but still lets a malicious or compromised server render multi-line overlays that mimic local prompts or status chrome inside the TUI. Collapse to a single escaped line or render server text in a fixed non-interactive container.
+
+## unnecessary-scope
+
+- (major) §4.3 sends `seed` in `MatchStart` even though the client architecture only uses authoritative snapshots plus a local echo ghost. That gives modified clients perfect foresight of future bags and sudden-death garbage gaps, creating a cheap bot/cheat vector for no stated gameplay need. Keep RNG state server-side and reveal only intentionally visible queue state.
+- (minor) §4.3 allocates a `Pause-request` wire bit even though no multiplayer pause behavior is specified anywhere else. Shipping undefined control surface in protocol v1 adds parser/state complexity and compatibility burden without user value. Remove it from v1 or mark the bit reserved=0 until semantics exist.
+
+## missing-risk
+
+- (major) §5.5 hardens frame parsing but says nothing about WebSocket handshake policy. If browser-originated WS handshakes are accepted, any website can use visitors' browsers to consume the node's tiny unauthenticated session/join budget, which is an avoidable public-edge DoS vector for a CLI-only service. Reject unexpected `Origin` headers and document that only non-browser clients are supported.
+- (major) §4.4/§5.5 depend almost entirely on per-IP buckets/counters even though a target user story is joining from behind a corporate proxy. That both weakens abuse resistance against distributed attackers and creates easy false positives for legitimate users behind shared egress. Add a non-IP admission signal (join token, proof-of-work, cookie, or edge filtering) or explicitly narrow the rollout assumptions.
+- (minor) §5.5.3 retains only `match_id,event,ip_hash,ts`, and the salt state is memory-only and reset on restart. On the one production node, that leaves you with too little evidence to investigate join abuse, rate-limit evasion, or disconnect storms, and it breaks the stated cross-rotation correlation story after any restart. Add bounded-cardinality reason fields and persist rotation state securely if 7-day correlation is a real requirement.
+
+## suggested-next-version
+
+v0.2.1
+
+<!-- samospec:critique v1 -->
+{
+  "findings": [
+    {
+      "category": "weak-implementation",
+      "text": "§3 says the host sees a raw IP, but §4.4/§5.5 replace that with a keyed IP hash. A keyed hash is not human-verifiable, so the host still cannot distinguish the intended friend from the first attacker who guessed or brute-forced the code; the claimed 'second credential' is therefore mostly illusory. Add a join fingerprint/PIN that both humans can compare, or make invites single-use and host-generated.",
+      "severity": "major"
+    },
+    {
+      "category": "unnecessary-scope",
+      "text": "§4.3 sends `seed` in `MatchStart` even though the client architecture only uses authoritative snapshots plus a local echo ghost. That gives modified clients perfect foresight of future bags and sudden-death garbage gaps, creating a cheap bot/cheat vector for no stated gameplay need. Keep RNG state server-side and reveal only intentionally visible queue state.",
+      "severity": "major"
+    },
+    {
+      "category": "weak-implementation",
+      "text": "§2.3/§4.3 define `seq` and `client_tick`, but the spec never defines duplicate handling, monotonicity rules, or max future skew. A malicious client can replay old inputs or send far-future ones to grow per-match queues, waste CPU on validation, or create ambiguous ordering semantics. Define a strict acceptance window and disconnect on violation.",
+      "severity": "major"
+    },
+    {
+      "category": "missing-risk",
+      "text": "§5.5 hardens frame parsing but says nothing about WebSocket handshake policy. If browser-originated WS handshakes are accepted, any website can use visitors' browsers to consume the node's tiny unauthenticated session/join budget, which is an avoidable public-edge DoS vector for a CLI-only service. Reject unexpected `Origin` headers and document that only non-browser clients are supported.",
+      "severity": "major"
+    },
+    {
+      "category": "missing-risk",
+      "text": "§4.4/§5.5 depend almost entirely on per-IP buckets/counters even though a target user story is joining from behind a corporate proxy. That both weakens abuse resistance against distributed attackers and creates easy false positives for legitimate users behind shared egress. Add a non-IP admission signal (join token, proof-of-work, cookie, or edge filtering) or explicitly narrow the rollout assumptions.",
+      "severity": "major"
+    },
+    {
+      "category": "weak-implementation",
+      "text": "§4.5 allows server-originated text to keep `\\n`. That blocks ANSI escapes but still lets a malicious or compromised server render multi-line overlays that mimic local prompts or status chrome inside the TUI. Collapse to a single escaped line or render server text in a fixed non-interactive container.",
+      "severity": "minor"
+    },
+    {
+      "category": "missing-risk",
+      "text": "§5.5.3 retains only `match_id,event,ip_hash,ts`, and the salt state is memory-only and reset on restart. On the one production node, that leaves you with too little evidence to investigate join abuse, rate-limit evasion, or disconnect storms, and it breaks the stated cross-rotation correlation story after any restart. Add bounded-cardinality reason fields and persist rotation state securely if 7-day correlation is a real requirement.",
+      "severity": "minor"
+    },
+    {
+      "category": "unnecessary-scope",
+      "text": "§4.3 allocates a `Pause-request` wire bit even though no multiplayer pause behavior is specified anywhere else. Shipping undefined control surface in protocol v1 adds parser/state complexity and compatibility burden without user value. Remove it from v1 or mark the bit reserved=0 until semantics exist.",
+      "severity": "minor"
+    }
+  ],
+  "summary": "Primary blockers are the fake second factor in host admission, unnecessary exposure of RNG state, and missing public-edge abuse controls. The spec is tighter than before, but several controls are written as if they solve an attack class when they mostly relocate it.",
+  "suggested_next_version": "v0.2.1",
+  "usage": null,
+  "effort_used": "max"
+}
+<!-- samospec:critique end -->

--- a/.samo/spec/multiplayer-v1/reviews/r02/round.json
+++ b/.samo/spec/multiplayer-v1/reviews/r02/round.json
@@ -1,0 +1,10 @@
+{
+  "round": 2,
+  "status": "complete",
+  "seats": {
+    "reviewer_a": "ok",
+    "reviewer_b": "ok"
+  },
+  "started_at": "2026-04-24T04:24:40.538Z",
+  "completed_at": "2026-04-24T04:27:44.780Z"
+}

--- a/.samo/spec/multiplayer-v1/state.json
+++ b/.samo/spec/multiplayer-v1/state.json
@@ -11,11 +11,11 @@
   "calibration": null,
   "remote_stale": false,
   "coupled_fallback": false,
-  "head_sha": null,
+  "head_sha": "dcfc01a95f88cb94f9e9fbf62264c90e74ba68d8",
   "round_state": "committed",
   "exit": null,
   "created_at": "2026-04-24T03:59:03.348Z",
-  "updated_at": "2026-04-24T04:24:40.410Z",
+  "updated_at": "2026-04-24T04:24:40.491Z",
   "input": {
     "idea": "Add two-player competitive multiplayer to blocktxt (v0.2)."
   }

--- a/.samo/spec/multiplayer-v1/state.json
+++ b/.samo/spec/multiplayer-v1/state.json
@@ -1,8 +1,8 @@
 {
   "slug": "multiplayer-v1",
   "phase": "draft",
-  "round_index": 0,
-  "version": "0.1.0",
+  "round_index": 1,
+  "version": "0.2.0",
   "persona": {
     "skill": "real-time multiplayer game networking engineer",
     "accepted": true
@@ -15,7 +15,7 @@
   "round_state": "committed",
   "exit": null,
   "created_at": "2026-04-24T03:59:03.348Z",
-  "updated_at": "2026-04-24T03:59:03.348Z",
+  "updated_at": "2026-04-24T04:24:40.410Z",
   "input": {
     "idea": "Add two-player competitive multiplayer to blocktxt (v0.2)."
   }

--- a/.samo/spec/multiplayer-v1/state.json
+++ b/.samo/spec/multiplayer-v1/state.json
@@ -11,11 +11,15 @@
   "calibration": null,
   "remote_stale": false,
   "coupled_fallback": false,
-  "head_sha": "dcfc01a95f88cb94f9e9fbf62264c90e74ba68d8",
-  "round_state": "committed",
-  "exit": null,
+  "head_sha": "55378aeb3f87cac9459aa974a1db882984f8fd4a",
+  "round_state": "lead_terminal",
+  "exit": {
+    "code": 4,
+    "reason": "lead-terminal:revise_timeout",
+    "round_index": 2
+  },
   "created_at": "2026-04-24T03:59:03.348Z",
-  "updated_at": "2026-04-24T04:24:40.491Z",
+  "updated_at": "2026-04-24T04:50:37.645Z",
   "input": {
     "idea": "Add two-player competitive multiplayer to blocktxt (v0.2)."
   }

--- a/.samo/spec/multiplayer-v1/state.json
+++ b/.samo/spec/multiplayer-v1/state.json
@@ -1,0 +1,22 @@
+{
+  "slug": "multiplayer-v1",
+  "phase": "draft",
+  "round_index": 0,
+  "version": "0.1.0",
+  "persona": {
+    "skill": "real-time multiplayer game networking engineer",
+    "accepted": true
+  },
+  "push_consent": null,
+  "calibration": null,
+  "remote_stale": false,
+  "coupled_fallback": false,
+  "head_sha": null,
+  "round_state": "committed",
+  "exit": null,
+  "created_at": "2026-04-24T03:59:03.348Z",
+  "updated_at": "2026-04-24T03:59:03.348Z",
+  "input": {
+    "idea": "Add two-player competitive multiplayer to blocktxt (v0.2)."
+  }
+}


### PR DESCRIPTION
## Draft — v0.2 multiplayer spec (samospec-generated)

Submitting as **draft** for review. The `samospec iterate` loop ran
**1 full round to convergence (v0.2 of the spec)** plus **round 2
reviewers** (16 + 8 findings captured on disk), then the round-2 lead
revise hit the 600 s call budget and exited 4 with
`lead-terminal:revise_timeout`. Neither reviewer's findings were
merged into a v0.3. The spec is **draft-quality**, not converged.

Resume after review: `samospec resume multiplayer-v1` or bump
`budget.max_revise_call_ms` and re-run.

## What samospec delivered

- `.samo/spec/multiplayer-v1/SPEC.md` — **837 lines** at v0.2.
- `decisions.md` — 35 lines of accepted round-1 findings.
- `reviews/r01/{codex,claude}.md` — round 1 (applied into v0.2).
- `reviews/r02/{codex,claude}.md` — round 2 findings (16 claude + 8
  codex) — **not yet applied**. Post-merge these are fodder for the
  next resume / a manual refinement pass.

## Design TL;DR (from SPEC §2)

| Decision | Choice | Rationale |
|---|---|---|
| Language | Rust client + server, shared simulation crate | Determinism + halves test surface |
| Topology | Authoritative central server ("relay + referee") | Simpler than P2P w/ NAT + no cheating surface |
| Sync | Server-authoritative 60 Hz fixed tick, 2-tick input delay | Absorbs jitter without rollback complexity |
| Transport | **WebSocket over TLS (`wss://`)** on port 443 | Firewall-friendly, one connection for matchmaking + game |
| Scale (v0.2) | Exactly 2 players/match; 60 Hz server; ≤ 150 ms RTT; ≤ 8 KiB/s steady; 200 matches per 1-vCPU/512 MiB | Single-region beta, single-node deployment |

**On the original prompt's "HTTP/2 / QUIC / gRPC / smart tunnels"
question** — the lead chose WSS over those for:
- Matchmaking + game traffic on ONE connection.
- Firewall-friendliness (corporate / school / coffee-shop Wi-Fi all
  let 443 through).
- Standard Rust tooling (`tokio-tungstenite`).
- No NAT traversal for v0.2 (see Non-Goals).

Tunnels / NAT traversal / WebRTC are explicitly called out as "v0.3
levers" — deferred out of this release.

## Non-goals (enforced)

Verbatim from SPEC §1:

- NOT spectator / streaming.
- NOT leaderboard / rating / Elo.
- NOT a lobby / chat / social product.
- NOT cross-version compatible (v0.2 ↔ v0.2 only).
- NOT a replacement for single-player.
- NOT > 2 players.
- NOT local/offline multiplayer (subcommand deferred).
- NOT horizontally scaled (single server node for v0.2 beta).

## Next steps (recommended)

1. **Review the spec as-is** — §2 decisions should get a human check.
2. **Apply the round-2 findings** — 16 + 8 flagged. Either resume
   samospec iterate (`samospec resume multiplayer-v1`) with a larger
   revise budget, or refine manually.
3. Decide: merge this branch into main as-is (spec-only, no code)
   OR converge further first.

## Process notes

- Branch `samospec/multiplayer-v1` created by the samospec new/iterate
  loop per its own convention.
- No code changes — this PR only touches `.samo/spec/multiplayer-v1/`.
- No CI impact (spec dir isn't scanned).
- Branch is safe to land in any order relative to the v0.1.1 release
  that shipped concurrently.

Generated via `bunx samospec@latest new/iterate` on 2026-04-24.
